### PR TITLE
Resolve undefined method error with eager loading enabled

### DIFF
--- a/lib/stimulus-rails.rb
+++ b/lib/stimulus-rails.rb
@@ -2,4 +2,5 @@ require "stimulus/version"
 require "stimulus/engine"
 
 module Stimulus
+  extend ActiveSupport::Autoload
 end


### PR DESCRIPTION
Because:

The following error happened when deploying a Rails 6.1 app to staging, which had `config.eager_load = true`, but which didn't happen in local development:

```
gems/railties-6.1.0/lib/rails/application/finisher.rb:134:in `each': undefined method `eager_load!' for Stimulus:Module (NoMethodError)
from gems/railties-6.1.0/lib/rails/application/finisher.rb:134:in `block in <module:Finisher>'
```

Solution:

* Extend `ActiveSupport::Autoload`, like the `turbo-rails` gem does
* This provides the `eager_load!` method, app moves past this error

This is effectively the same as https://github.com/hotwired/hotwire-rails/pull/4.