### PR TITLE
Make Autoloading more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -yqq install libsqlite3-dev chromium-browser
+        bundle install --jobs 4 --retry 3
+
+    - name: Test
+      run: bin/test test/**/*_test.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Specify your gem's dependencies in hotwire-rails.gemspec.
+# Specify your gem's dependencies in stimulus-rails.gemspec.
 gemspec
 
 gem "sqlite3"
+
+group :test do
+  gem "capybara"
+  gem "selenium-webdriver"
+  gem "webdrivers"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,18 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.10.0)
@@ -90,6 +101,7 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -121,6 +133,11 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rake (13.0.3)
+    regexp_parser (1.8.2)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -132,17 +149,26 @@ GEM
     thor (1.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    webdrivers (4.4.2)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
+  selenium-webdriver
   sqlite3
   stimulus-rails!
+  webdrivers
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/app/assets/javascripts/stimulus/loaders/autoloader.js
+++ b/app/assets/javascripts/stimulus/loaders/autoloader.js
@@ -2,40 +2,44 @@ import { Application } from "stimulus"
 
 const application = Application.start()
 const { controllerAttribute } = application.schema
+const registeredControllers = {}
 
-const loaded = {}
-
-function autoloadControllers(element) {
-  controllerNamesInElement(element).forEach(loadController)
+function autoloadControllersWithin(element) {
+  queryControllerNamesWithin(element).forEach(loadController)
 }
 
-function controllerNamesInElement(element) {
-  const elements = Array.from(element.querySelectorAll(`[${controllerAttribute}]`))
-  return elements.map(e => e.getAttribute(controllerAttribute).split(/\s+/).filter(content => content.length)).flat()
+function queryControllerNamesWithin(element) {
+  return Array.from(element.querySelectorAll(`[${controllerAttribute}]`)).map(extractControllerNamesFrom).flat()
 }
 
-function register(name, module) {
-  if (name in loaded) return
-
-  application.register(name, module.default)
-
-  loaded[name] = true
+function extractControllerNamesFrom(element) {
+  return element.getAttribute(controllerAttribute).split(/\s+/).filter(content => content.length)
 }
 
 function loadController(name) {
-  const filename = name.replace(/--/g, "/").replace(/-/g, "_")
-
-  import(`${filename}_controller`)
-    .then(module => register(name, module))
+  import(controllerFilename(name))
+    .then(module => registerController(name, module))
     .catch(error => console.log(`Failed to autoload controller: ${name}`, error))
 }
+
+function controllerFilename(name) {
+  return `${name.replace(/--/g, "/").replace(/-/g, "_")}_controller`
+}
+
+function registerController(name, module) {
+  if (name in registeredControllers) return
+
+  application.register(name, module.default)
+  registeredControllers[name] = true
+}
+
 
 new MutationObserver((mutationsList) => {
   for (const { attributeName, target } of mutationsList) {
     if (attributeName == controllerAttribute && target.hasAttribute(controllerAttribute)) {
-      autoloadControllers(target)
+      autoloadControllersWithin(target)
     }
   }
 }).observe(document.body, { attributeFilter: [controllerAttribute], subtree: true, childList: true })
 
-autoloadControllers(document)
+autoloadControllersWithin(document)

--- a/app/assets/javascripts/stimulus/loaders/autoloader.js
+++ b/app/assets/javascripts/stimulus/loaders/autoloader.js
@@ -1,24 +1,41 @@
 import { Application } from "stimulus"
 
 const application = Application.start()
+const { controllerAttribute } = application.schema
 
-function autoloadControllers() {
-  controllerNamesInDocument().forEach(loadController)
-}
+const loaded = {}
 
-function controllerNamesInDocument() {
-  return Array.from(document.querySelectorAll("[data-controller]")).map(controllerNamesInElement).flat()
+function autoloadControllers(element) {
+  controllerNamesInElement(element).forEach(loadController)
 }
 
 function controllerNamesInElement(element) {
-  return element.attributes["data-controller"].value.split(" ")
+  const elements = Array.from(element.querySelectorAll(`[${controllerAttribute}]`))
+  return elements.map(e => e.getAttribute(controllerAttribute).split(/\s+/).filter(content => content.length)).flat()
+}
+
+function register(name, module) {
+  if (name in loaded) return
+
+  application.register(name, module.default)
+
+  loaded[name] = true
 }
 
 function loadController(name) {
-  import(`${name}_controller`)
-    .then(module => application.register(name, module.default))
+  const filename = name.replace(/--/g, "/").replace(/-/g, "_")
+
+  import(`${filename}_controller`)
+    .then(module => register(name, module))
     .catch(error => console.log(`Failed to autoload controller: ${name}`, error))
 }
 
-autoloadControllers()
-window.addEventListener("turbo:load", autoloadControllers)
+new MutationObserver((mutationsList) => {
+  for (const { attributeName, target } of mutationsList) {
+    if (attributeName == controllerAttribute && target.hasAttribute(controllerAttribute)) {
+      autoloadControllers(target)
+    }
+  }
+}).observe(document.body, { attributeFilter: [controllerAttribute], subtree: true, childList: true })
+
+autoloadControllers(document)

--- a/app/helpers/stimulus/stimulus_helper.rb
+++ b/app/helpers/stimulus/stimulus_helper.rb
@@ -1,10 +1,10 @@
 module Stimulus::StimulusHelper
   def stimulus_include_tags
-    [
+    safe_join [
       javascript_include_tag("stimulus/libraries/es-module-shims", type: "module"),
       tag.script(type: "importmap-shim", src: asset_path("importmap.json")),
       javascript_include_tag("stimulus/libraries/stimulus", type: "module-shim"),
       javascript_include_tag("stimulus/loaders/autoloader", type: "module-shim")
-    ].join("\n").html_safe
+    ], "\n"
   end
 end

--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -6,11 +6,10 @@ module Stimulus::ImportmapHelper
   def importmap_list_from(*paths)
     Array(paths).flat_map do |path|
       if (absolute_path = Rails.root.join(path)).exist?
-        dirname = absolute_path.basename
-        Dir[absolute_path.join("**/*.js{,m}")].collect { |file| Pathname.new(file) }.select(&:file?).collect do |filename|
+        find_javascript_files_in_tree(absolute_path).collect do |filename|
           module_filename = filename.relative_path_from(absolute_path)
-          module_name = importmap_module_name_from(module_filename)
-          module_path = asset_path(dirname.join(module_filename))
+          module_name     = importmap_module_name_from(module_filename)
+          module_path     = asset_path(absolute_path.basename.join(module_filename))
 
           %("#{module_name}": "#{module_path}")
         end
@@ -22,5 +21,9 @@ module Stimulus::ImportmapHelper
     # Strip off the extension and any versioning data for an absolute module name.
     def importmap_module_name_from(filename)
       filename.to_s.remove(filename.extname).split("@").first
+    end
+
+    def find_javascript_files_in_tree(path)
+      Dir[path.join("**/*.js{,m}")].collect { |file| Pathname.new(file) }.select(&:file?)
     end
 end

--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -6,11 +6,11 @@ module Stimulus::ImportmapHelper
   def importmap_list_from(*paths)
     Array(paths).flat_map do |path|
       if (absolute_path = Rails.root.join(path)).exist?
-        absolute_path.children.collect do |module_filename|
-          next unless module_filename.extname =~ /js(m)?$/
-          
+        dirname = absolute_path.basename
+        Dir[absolute_path.join("**/*.js{,m}")].collect { |file| Pathname.new(file) }.select(&:file?).collect do |filename|
+          module_filename = filename.relative_path_from(absolute_path)
           module_name = importmap_module_name_from(module_filename)
-          module_path = asset_path("#{absolute_path.basename.to_s}/#{module_filename.basename}")
+          module_path = asset_path(dirname.join(module_filename))
 
           %("#{module_name}": "#{module_path}")
         end
@@ -21,6 +21,6 @@ module Stimulus::ImportmapHelper
   private
     # Strip off the extension and any versioning data for an absolute module name.
     def importmap_module_name_from(filename)
-      filename.basename.to_s.remove(filename.extname).split("@").first
+      filename.to_s.remove(filename.extname).split("@").first
     end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+Capybara.server = :webrick
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+end

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_tree ../javascripts

--- a/test/dummy/app/assets/javascripts/controllers/message_rendering_controller.js
+++ b/test/dummy/app/assets/javascripts/controllers/message_rendering_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static values = { message: String }
+
+  connect() {
+    this.element.innerHTML = this.messageValue
+  }
+}

--- a/test/dummy/app/assets/javascripts/controllers/namespace/message_rendering_controller.js
+++ b/test/dummy/app/assets/javascripts/controllers/namespace/message_rendering_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static values = { message: String }
+
+  connect() {
+    this.element.innerHTML = `Namespace: ${this.messageValue}`
+  }
+}

--- a/test/dummy/app/assets/javascripts/importmap.json.erb
+++ b/test/dummy/app/assets/javascripts/importmap.json.erb
@@ -1,0 +1,5 @@
+{
+  "imports": { 
+    <%= importmap_list_with_stimulus_from "app/assets/javascripts/controllers", "app/assets/javascripts/libraries" %>
+  }
+}

--- a/test/dummy/app/views/application/index.html.erb
+++ b/test/dummy/app/views/application/index.html.erb
@@ -1,0 +1,6 @@
+<%= tag.p "", data: { message_rendering_message_value: params[:message], controller: "
+  message-rendering
+" } %>
+<%= tag.p "", data: { namespace__message_rendering_message_value: params[:message], controller: "
+  namespace--message-rendering
+" } %>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= stimulus_include_tags %>
   </head>
 
   <body>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root to: "application#index"
 end

--- a/test/stimulus_test.rb
+++ b/test/stimulus_test.rb
@@ -4,14 +4,20 @@ class StimulusTest < ActionView::TestCase
   include Stimulus::ImportmapHelper
 
   test "import map helper with files in directories" do
-    assert_equal \
-      %("hello_controller": "/controllers/hello_controller.js",\n"cookie": "/libraries/cookie@1.0.js"),
-      importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries")
+    assert_equal <<~JSON.strip, importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries")
+      "hello_controller": "/controllers/hello_controller.js",
+      "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
+      "message_rendering_controller": "/controllers/message_rendering_controller.js",
+      "cookie": "/libraries/cookie@1.0.js"
+    JSON
   end
 
   test "import map helper with no files in some directories" do
-    assert_equal \
-      %("hello_controller": "/controllers/hello_controller.js",\n"cookie": "/libraries/cookie@1.0.js"),
-      importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries", "app/assets/noexistent")
+    assert_equal <<~JSON.strip, importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries", "app/assets/noexistent")
+      "hello_controller": "/controllers/hello_controller.js",
+      "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
+      "message_rendering_controller": "/controllers/message_rendering_controller.js",
+      "cookie": "/libraries/cookie@1.0.js"
+    JSON
   end
 end

--- a/test/system/autoload_test.rb
+++ b/test/system/autoload_test.rb
@@ -1,0 +1,10 @@
+require "application_system_test_case"
+
+class AutoloadTest < ApplicationSystemTestCase
+  test "autoloads Controller modules on the page" do
+    visit root_path(message: "Hello, from a System Test")
+
+    assert_text "Hello, from a System Test"
+    assert_text "Namespace: Hello, from a System Test"
+  end
+end


### PR DESCRIPTION
Duplicate of #3
Closes https://github.com/hotwired/stimulus-rails/issues/4
Closes https://github.com/hotwired/stimulus-rails/issues/14

Modifies the `stimulus/loaders/autoloader` module to account for module
importing in 4 different scenarios:

1. Immediately when parsed
2. Whenever elements that declare `[data-controller]` are added,
   deleted, or modified (via a [MutationObserver][])
3. Whenever the `DOMContentLoaded` event fires (for applications that
   don't depend on `turbo`
4. Whenever the `turbo:load` event fires (for applications that **do**
   depend on `turbo`

In addition to autoloading in more scenarios, this commit also changes
the autoloader to read controller tokens in a spacing-agnostic manner,
and to transform [dasherized controller names (like
`message-rendering`)][modules] to underscored file names (like
`message_rendering_controller.js`).

The changes made to `test/dummy` were done so manually, and are being
checked into version control. In an ideal set up, the generator would be
run for every System Test, and then reverted.

Testing
---

Add System Test level coverage to ensure that the configurations,
helpers, and autoloading work together in concert to dynamically load
Stimulus Controllers.

To do so, add a `Gemfile`-level dependency on `capybara`, `webdrivers`,
and `selenium-webdrivers`.

[MutationObserver]: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
[modules]: https://stimulus.hotwire.dev/reference/controllers#modules

Co-authored-by: Justin Malčić <j.malcic@me.com>