### PR TITLE
patch - the issue of no such file or directory

### DIFF
--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -6,6 +6,7 @@ module Stimulus::ImportmapHelper
   def importmap_list_from(*paths)
     Array(paths).flat_map do |path|
       absolute_path = Rails.root.join(path)
+      next [] unless absolute_path.exist?
       dirname       = absolute_path.basename.to_s
 
       absolute_path.children.collect do |module_filename|


### PR DESCRIPTION
The initial `app/assets/javascipts/libraries` is empty. It means the directory will not be committed to a git repo. When other people check out  the project, run the application will see the exception:
```
Errno::ENOENT (No such file or directory @ dir_initialize - app/assets/javascripts/libraries)
```

This patch resolved the issue mentioned above.