### PR TITLE
Add .keep file to empty directory

### DIFF
--- a/lib/install/stimulus.rb
+++ b/lib/install/stimulus.rb
@@ -1,6 +1,6 @@
 say "Copying Stimulus JavaScript"
 directory "#{__dir__}/app/assets/javascripts", "app/assets/javascripts"
-empty_directory "app/assets/javascripts/libraries"
+empty_directory_with_keep_file "app/assets/javascripts/libraries"
 
 say "Add app/javascripts to asset pipeline manifest"
 append_to_file Rails.root.join("app/assets/config/manifest.js").to_s, "//= link_tree ../javascripts\n"


### PR DESCRIPTION
When trying to deploy the following error happened to me:

```
Errno::ENOENT: No such file or directory @ dir_initialize - /tmp/build_00ed1b07/app/assets/javascripts/libraries
```

It was because the folder was empty thus not committed with Git.
This commit just adds the file, so we always ensure the folder is committed.