### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The last command will:
 1. Create an example controller in `app/assets/javascripts/controllers/hello_controller.js`
 2. Append the include tags to the `<head>` of your `app/views/layouts/application.html.erb`.
 3. Initialize your `importmap.json` in `app/assets/javascripts/importmap.json.erb`.
-4. Ensure JavaScript is included in your `app/config/manifest.js` file for compilation.
+4. Ensure JavaScript is included in your `app/assets/config/manifest.js` file for compilation.
 
 
 ## Usage


### PR DESCRIPTION

![Screenshot from 2021-01-10 22-32-04](https://user-images.githubusercontent.com/721990/104136054-20790780-5394-11eb-93d1-9d22982de759.png)
It seems to me this should be `app/assets/config/manifest.js` (not `app/config/manifest.js`) .