### PR TITLE
Improve Autoloader

### DIFF
--- a/app/assets/javascripts/stimulus/loaders/autoloader.js
+++ b/app/assets/javascripts/stimulus/loaders/autoloader.js
@@ -35,9 +35,16 @@ function registerController(name, module) {
 
 
 new MutationObserver((mutationsList) => {
-  for (const { attributeName, target } of mutationsList) {
-    if (attributeName == controllerAttribute && target.hasAttribute(controllerAttribute)) {
-      autoloadControllersWithin(target)
+  for (const { attributeName, target, type } of mutationsList) {
+    switch (type) {
+      case "attributes": {
+        if (attributeName == controllerAttribute && target.hasAttribute(controllerAttribute)) {
+          extractControllerNamesFrom(target).forEach(loadController)
+        }
+      }
+      case "childList": {
+        autoloadControllersWithin(target)
+      }
     }
   }
 }).observe(document.body, { attributeFilter: [controllerAttribute], subtree: true, childList: true })

--- a/test/dummy/app/assets/javascripts/controllers/loading_controller.js
+++ b/test/dummy/app/assets/javascripts/controllers/loading_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static values = { controller: String, html: String }
+
+  loadController() {
+    this.element.setAttribute(this.application.schema.controllerAttribute, this.controllerValue)
+  }
+
+  injectController() {
+    this.element.insertAdjacentHTML("beforeend", this.htmlValue)
+  }
+}

--- a/test/dummy/app/views/application/index.html.erb
+++ b/test/dummy/app/views/application/index.html.erb
@@ -1,6 +1,18 @@
-<%= tag.p "", data: { message_rendering_message_value: params[:message], controller: "
-  message-rendering
-" } %>
-<%= tag.p "", data: { namespace__message_rendering_message_value: params[:message], controller: "
-  namespace--message-rendering
-" } %>
+<section id="eager-loaded">
+  <%= tag.p "", data: { message_rendering_message_value: params[:message], controller: "
+    message-rendering
+  " } %>
+  <%= tag.p "", data: { namespace__message_rendering_message_value: params[:message], controller: "
+    namespace--message-rendering
+  " } %>
+</section>
+
+<section id="load-attribute" data-controller="loading" data-loading-controller-value="message-rendering" data-message-rendering-message-value="<%= params[:message] %>">
+  <button data-action="loading#loadController">Load</button>
+</section>
+
+<section id="load-descendant" data-controller="loading" data-loading-html-value="<%=
+  html_escape %(<div data-controller="message-rendering" data-message-rendering-message-value="#{params[:message]}"></div>)
+%>">
+  <button data-action="loading#injectController">Load</button>
+</section>

--- a/test/stimulus_test.rb
+++ b/test/stimulus_test.rb
@@ -6,6 +6,7 @@ class StimulusTest < ActionView::TestCase
   test "import map helper with files in directories" do
     assert_json_equal <<~JSON.strip, importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries")
       "hello_controller": "/controllers/hello_controller.js",
+      "loading_controller": "/controllers/loading_controller.js",
       "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
       "message_rendering_controller": "/controllers/message_rendering_controller.js",
       "cookie": "/libraries/cookie@1.0.js"
@@ -15,6 +16,7 @@ class StimulusTest < ActionView::TestCase
   test "import map helper with no files in some directories" do
     assert_json_equal <<~JSON.strip, importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries", "app/assets/noexistent")
       "hello_controller": "/controllers/hello_controller.js",
+      "loading_controller": "/controllers/loading_controller.js",
       "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
       "message_rendering_controller": "/controllers/message_rendering_controller.js",
       "cookie": "/libraries/cookie@1.0.js"

--- a/test/system/autoload_test.rb
+++ b/test/system/autoload_test.rb
@@ -1,10 +1,28 @@
 require "application_system_test_case"
 
 class AutoloadTest < ApplicationSystemTestCase
-  test "autoloads Controller modules on the page" do
+  test "autoloads Controller modules on the page eagerly" do
     visit root_path(message: "Hello, from a System Test")
 
-    assert_text "Hello, from a System Test"
-    assert_text "Namespace: Hello, from a System Test"
+    within "#eager-loaded" do
+      assert_text "Hello, from a System Test"
+      assert_text "Namespace: Hello, from a System Test"
+    end
+  end
+
+  test "autoloads Controller modules on the page lazily" do
+    visit root_path(message: "Hello World!")
+
+    within "#load-attribute" do
+      assert_no_text "Hello World!"
+
+      click_on("Load").then { assert_text "Hello World!" }
+    end
+
+    within "#load-descendant" do
+      assert_no_text "Hello World!"
+
+      click_on("Load").then { assert_text "Hello World!" }
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/hotwired/stimulus-rails/issues/27

To handle both types of element mutations of interest, [treat
`attributes` mutations different from `childList`
mutations][MutationRecord]. When an `attributes` mutation occurs, load
the added controllers. When a `childList` mutation occurs, load
controllers from any descendant elements.

[MutationRecord]: https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord

Co-authored-by: Justin Malčić <j.malcic@me.com>