### PR TITLE
Implementing Confirmation and Disable Controllers

### DIFF
--- a/app/assets/javascripts/stimulus/controllers/confirmation_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/confirmation_controller.js
@@ -6,7 +6,10 @@ export default class extends Controller {
   // Listen to form:submit
   confirm(event) {
     if (!(window.confirm(this.messageValue))) {
+      var customEvent = new CustomEvent("submitcanceled")
+
       event.preventDefault()
-    };
-  };
+      this.element.dispatchEvent(customEvent)
+    }
+  }
 }

--- a/app/assets/javascripts/stimulus/controllers/confirmation_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/confirmation_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static values = { message: String };
+
+  // Listen to form:submit
+  confirm(event) {
+    if (!(window.confirm(this.messageValue))) {
+      event.preventDefault()
+    };
+  };
+}

--- a/app/assets/javascripts/stimulus/controllers/disable_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/disable_controller.js
@@ -2,11 +2,18 @@ import { Controller } from "stimulus"
 
 export default class extends Controller {
   static targets = [ "button" ]
-  static values = { message: String }
+  static values = { disableMessage: String, originalText: String  }
 
   // Listen to form:submit
   disable() {
-    this.buttonTarget.disabled = true;
-    this.buttonTarget.value = this.messageValue;
+    this.originalTextValue = this.buttonTarget.value
+    this.buttonTarget.disabled = true
+    this.buttonTarget.value = this.disableMessageValue
+  }
+
+  // Listen to form:submitcanceled
+  enable() {
+    this.buttonTarget.disabled = false
+    this.buttonTarget.value = this.originalTextValue
   }
 }

--- a/app/assets/javascripts/stimulus/controllers/disable_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/disable_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "button" ]
+  static values = { message: String }
+
+  // Listen to form:submit
+  disable() {
+    this.buttonTarget.disabled = true;
+    this.buttonTarget.value = this.messageValue;
+  }
+}


### PR DESCRIPTION
I'm making this PR in response to [this discussion](https://github.com/hotwired/stimulus-rails/pull/24#issuecomment-763851711). So far I've managed to get these controllers working in isolation, but I'm having trouble with getting them to play well together.

I wanted to open this as a draft PR to see thoughts on how to prevent the submit event from propagating to other controllers if the confirmation is declined, regardless of invocation order. I'm considering combining the controllers into a single `form_controller`, but I'm not sure if this is appropriate. Additionally, this doesn't solve the event propagation issue for other controllers listening to `submit`.