### PR TITLE
Attach MutationObserver to `document`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "sqlite3"
+gem "turbo-rails", github: "hotwired/turbo-rails", branch: "main"
 
 group :test do
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/hotwired/turbo-rails.git
+  revision: 551890dba1aa23f1a84be77820f96a458723f1a9
+  branch: main
+  specs:
+    turbo-rails (0.5.7)
+      rails (>= 6.0.0)
+
 PATH
   remote: .
   specs:
@@ -168,6 +176,7 @@ DEPENDENCIES
   selenium-webdriver
   sqlite3
   stimulus-rails!
+  turbo-rails!
   webdrivers
 
 BUNDLED WITH

--- a/app/assets/javascripts/stimulus/loaders/autoloader.js
+++ b/app/assets/javascripts/stimulus/loaders/autoloader.js
@@ -47,6 +47,6 @@ new MutationObserver((mutationsList) => {
       }
     }
   }
-}).observe(document.body, { attributeFilter: [controllerAttribute], subtree: true, childList: true })
+}).observe(document, { attributeFilter: [controllerAttribute], subtree: true, childList: true })
 
 autoloadControllersWithin(document)

--- a/test/dummy/app/views/application/no_controllers.html.erb
+++ b/test/dummy/app/views/application/no_controllers.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Load", root_path(message: "Hello, from another page") %>

--- a/test/dummy/app/views/application/turbo.html.erb
+++ b/test/dummy/app/views/application/turbo.html.erb
@@ -1,0 +1,5 @@
+<% content_for :head do %>
+  <%= javascript_include_tag "turbo", type: "module" %>
+<% end %>
+
+<%= link_to "Load", root_path(message: "Hello, from Turbo page") %>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= stimulus_include_tags %>
+    <%= yield :head %>
   </head>
 
   <body>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get "/no_controllers/turbo" => "application#turbo", as: :turbo
+  get "/no_controllers" => "application#no_controllers", as: :no_controllers
+
   root to: "application#index"
 end

--- a/test/system/autoload_test.rb
+++ b/test/system/autoload_test.rb
@@ -25,4 +25,24 @@ class AutoloadTest < ApplicationSystemTestCase
       click_on("Load").then { assert_text "Hello World!" }
     end
   end
+
+  test "autoloads Controller modules when the page is navigated to" do
+    visit no_controllers_path
+
+    click_on "Load"
+    within "#eager-loaded" do
+      assert_text "Hello, from another page"
+      assert_text "Namespace: Hello, from another page"
+    end
+  end
+
+  test "autoloads Controller modules when the page is navigated to via Turbo" do
+    visit turbo_path
+
+    click_on "Load"
+    within "#eager-loaded" do
+      assert_text "Hello, from Turbo page"
+      assert_text "Namespace: Hello, from Turbo page"
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/hotwired/hotwire-rails/issues/19

---

Instead of attaching the `MutationObserver` to the `document.body`
element, this commit instead attaches it to the `document` itself so
that observation spans Turbo-powered `HTMLBodyElement.innerHTML`
re-assignment.

Add test coverage to reproduce the behavior reported by
[hotwired/hotwire-rails#19][] and ensure that navigating between pages
does not break controller autoloading.

Prior to this commit, navigations triggered via Turbo visits would not
autoload controllers. This commit adds test coverage integrating with
Turbo the `turbo-rails` gem.

[hotwired/hotwire-rails#19]: https://github.com/hotwired/hotwire-rails/issues/19
