### PR TITLE
Add checkbox-list controller

### DIFF
--- a/app/assets/javascripts/stimulus/controllers/checkbox_list_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/checkbox_list_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  // Actions
+
+  checkAll() {
+    this.setAllCheckboxes(true)
+  }
+
+  checkNone() {
+    this.setAllCheckboxes(false)
+  }
+
+  // Private
+
+  setAllCheckboxes(checked) {
+    this.checkboxes.forEach((el) => {
+      const checkbox = el
+
+      if (!checkbox.disabled) {
+        checkbox.checked = checked
+      }
+    });
+  }
+
+  get checkboxes() {
+    return this.element.querySelectorAll("input[type=checkbox]")
+  }
+}

--- a/app/assets/javascripts/stimulus/controllers/checkbox_list_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/checkbox_list_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
       if (!checkbox.disabled) {
         checkbox.checked = checked
       }
-    });
+    })
   }
 
   get checkboxes() {


### PR DESCRIPTION
Proposal for a `checkbox-list` controller. No targets, just `checkAll` / `checkNone` actions that set the `checked` value of any non-disabled child checkboxes.

I have a version that binds a `counter` target to check the number of items selected (useful for bulk actions) that I'm happy to share if there is interest, but opted for the simplest version for now.

@dhh 

Examples:

![image](https://user-images.githubusercontent.com/56947/105259845-92064200-5b5a-11eb-9114-d3fa2548f14a.png)

![email-preferences](https://user-images.githubusercontent.com/56947/105260022-004b0480-5b5b-11eb-8322-a95b7d7230cf.gif)

![image](https://user-images.githubusercontent.com/56947/105259601-1e643500-5b5a-11eb-8b31-dab62857f453.png)
(`Clear filter` unchecks all)

✌️ 