### PR TITLE
add index for webpacker

### DIFF
--- a/lib/install/app/assets/javascripts/controllers/index.js
+++ b/lib/install/app/assets/javascripts/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories. 
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))


### PR DESCRIPTION
Hi, this PR comes from #33. 

Now `stimulus:install:webpacker` will lead to an error but `webpacker:install:stimulus` won't.
After comparing the code, I find `stimulus` has missed this setup file to work. This file is taken from  [webpacker](https://github.com/rails/webpacker/blob/v4.0.0/lib/install/examples/stimulus/controllers/index.js).

Thanks for your hard work 😄 
