### PR TITLE
Use getAttribute to ignore empty controller name

### DIFF
--- a/app/assets/javascripts/stimulus/loaders/autoloader.js
+++ b/app/assets/javascripts/stimulus/loaders/autoloader.js
@@ -38,7 +38,7 @@ new MutationObserver((mutationsList) => {
   for (const { attributeName, target, type } of mutationsList) {
     switch (type) {
       case "attributes": {
-        if (attributeName == controllerAttribute && target.hasAttribute(controllerAttribute)) {
+        if (attributeName == controllerAttribute && target.getAttribute(controllerAttribute)) {
           extractControllerNamesFrom(target).forEach(loadController)
         }
       }


### PR DESCRIPTION
Skip if provided an empty string

![image](https://user-images.githubusercontent.com/11586335/105664847-a35f9d80-5f10-11eb-8bb0-924d16068c55.png)
