### PR TITLE
Fix imports JSON when no files to load

### DIFF
--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -1,6 +1,7 @@
 module Stimulus::ImportmapHelper
   def importmap_list_with_stimulus_from(*paths)
-    [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ].join(",\n")
+    imports = [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ]
+    imports.excluding("").join(",\n")
   end
 
   def importmap_list_from(*paths)

--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -1,7 +1,6 @@
 module Stimulus::ImportmapHelper
   def importmap_list_with_stimulus_from(*paths)
-    imports = [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ]
-    imports.excluding("").join(",\n")
+    [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ].compact_blank.join(",\n")
   end
 
   def importmap_list_from(*paths)

--- a/test/stimulus_test.rb
+++ b/test/stimulus_test.rb
@@ -13,13 +13,19 @@ class StimulusTest < ActionView::TestCase
     JSON
   end
 
-  test "import map helper with no files in some directories" do
+  test "import map helper with some non existent directories" do
     assert_json_equal <<~JSON.strip, importmap_list_from("app/assets/javascripts/controllers", "app/assets/javascripts/libraries", "app/assets/noexistent")
       "hello_controller": "/controllers/hello_controller.js",
       "loading_controller": "/controllers/loading_controller.js",
       "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
       "message_rendering_controller": "/controllers/message_rendering_controller.js",
       "cookie": "/libraries/cookie@1.0.js"
+    JSON
+  end
+
+  test "import map list helper with nothing to load" do
+    assert_json_equal <<~JSON.strip, importmap_list_with_stimulus_from("app/components")
+      "stimulus": "/stimulus/libraries/stimulus"
     JSON
   end
 


### PR DESCRIPTION
There is a small issue in the import map helper when ALL folders exists and have no files to load. It generates a malformed JSON like this one (note the 'extra' comma):

```
{
  "imports": {
    "stimulus": "/assets/stimulus/libraries/stimulus-dcca1023.js",
  }
}

```

using the default `importmap.json.erb`:

```
{
  "imports": { 
    <%= importmap_list_with_stimulus_from "app/assets/javascripts/controllers", "app/assets/javascripts/libraries" %>
  }
}
```
and both folders have no js files to load.

This is because the `[].join` will return an empty string `""` in `importmap_list_from` and later this will become in the extra comma and the malformed JSON. 

I've decided just exclude the empty string, but you're welcome to propose something different.

PS: this case can easily happen when you start a project and remove the hello_controller but keep the default folders in the `importmap.json.erb`