### PR TITLE
Support absolute paths (and thereby Rails engines)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    stimulus-rails (0.2.2)
+    stimulus-rails (0.2.3)
       rails (>= 6.0.0)
 
 GEM
@@ -180,4 +180,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.2.3
+   2.2.5

--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -5,7 +5,7 @@ module Stimulus::ImportmapHelper
 
   def importmap_list_from(*paths)
     Array(paths).flat_map do |path|
-      if (absolute_path = Rails.root.join(path)).exist?
+      if (absolute_path = absolute_root_of(path)).exist?
         find_javascript_files_in_tree(absolute_path).collect do |filename|
           module_filename = filename.relative_path_from(absolute_path)
           module_name     = importmap_module_name_from(module_filename)
@@ -25,5 +25,9 @@ module Stimulus::ImportmapHelper
 
     def find_javascript_files_in_tree(path)
       Dir[path.join("**/*.js{,m}")].collect { |file| Pathname.new(file) }.select(&:file?)
+    end
+
+    def absolute_root_of(path)
+      path.start_with?(File::SEPARATOR) ? path : Rails.root.join(path)
     end
 end

--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -28,6 +28,6 @@ module Stimulus::ImportmapHelper
     end
 
     def absolute_root_of(path)
-      path.start_with?(File::SEPARATOR) ? path : Rails.root.join(path)
+      (pathname = Pathname.new(path)).absolute? ? pathname : Rails.root.join(path)
     end
 end

--- a/lib/stimulus/version.rb
+++ b/lib/stimulus/version.rb
@@ -1,3 +1,3 @@
 module Stimulus
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/test/stimulus_test.rb
+++ b/test/stimulus_test.rb
@@ -23,6 +23,16 @@ class StimulusTest < ActionView::TestCase
     JSON
   end
 
+  test "import map helper with absolute path and a absolute path as string" do
+    assert_json_equal <<~JSON.strip, importmap_list_from(Rails.root.join("app/assets/javascripts/controllers"), Rails.root.join("app/assets/javascripts/libraries").to_s)
+      "hello_controller": "/controllers/hello_controller.js",
+      "loading_controller": "/controllers/loading_controller.js",
+      "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
+      "message_rendering_controller": "/controllers/message_rendering_controller.js",
+      "cookie": "/libraries/cookie@1.0.js"
+    JSON
+  end
+
   test "import map list helper with nothing to load" do
     assert_json_equal <<~JSON.strip, importmap_list_with_stimulus_from("app/components")
       "stimulus": "/stimulus/libraries/stimulus"


### PR DESCRIPTION
This PR adds support for absolute paths to be included in the `importmap.json` file, as mentioned in #38 . This is especially useful when including stimulus controllers found in a Rails engine. Supports both Pathname and string paths, passed to it.

Example:

```
{
  "imports": {
    "turbo": "<%= asset_path("turbo") %>",
    <%= importmap_list_with_stimulus_from "app/assets/javascripts/controllers", "app/assets/javascripts/libraries", "#{AppKit::Engine.root}/app/assets/javascripts/controllers", "#{AppKit::Engine.root}/app/assets/javascripts/libraries" %>
  }
}
```

Thanks!
Bjorn