### PR TITLE
Append webpacker stimulus install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to use Stimulus with a bundler, you should use [Webpacker](https://g
 
 1. Add the `stimulus-rails` gem to your Gemfile: `gem 'stimulus-rails'`
 2. Run `./bin/bundle install`.
-3. Run `./bin/rails stimulus:install`
+3. Run `./bin/rails stimulus:install` for asset pipeline or `./bin/rails webpacker:install:stimulus` for webpacker.
 
 If using the asset pipeline to manage JavaScript, the last command will:
 


### PR DESCRIPTION
In a new rails install, I ran into the following issue when installing stimulus with webpacker:

https://github.com/hotwired/hotwire-rails/issues/2#issuecomment-770110678

The `index.js` file was missing. This other comment helped me out:

https://github.com/hotwired/hotwire-rails/issues/20#issuecomment-770203853

Adding this command as a reference will hopefully cut down on any future confusion. 