### PR TITLE
Allow including importmap from custom location

### DIFF
--- a/app/helpers/stimulus/stimulus_helper.rb
+++ b/app/helpers/stimulus/stimulus_helper.rb
@@ -1,8 +1,8 @@
 module Stimulus::StimulusHelper
-  def stimulus_include_tags
+  def stimulus_include_tags(importmap = "importmap.json")
     safe_join [
       javascript_include_tag("stimulus/libraries/es-module-shims", type: "module"),
-      tag.script(type: "importmap-shim", src: asset_path("importmap.json")),
+      tag.script(type: "importmap-shim", src: asset_path(importmap)),
       javascript_include_tag("stimulus/libraries/stimulus", type: "module-shim"),
       javascript_include_tag("stimulus/loaders/autoloader", type: "module-shim")
     ], "\n"


### PR DESCRIPTION
This is needed when using the importmap provided by some Engine.
The path of the importmap is probably namespaced under some directories to avoid collisions with other Engines.

A practical example: 

Imagine there's a gem that distributes its own layout file with its own assets. We have this code in its `<head>` tag:

```erb
# my_gem/app/views/layouts/application.html.erb

<head>
  <%= stimulus_include_tags("importmap.json") %>
  ...
</head>
```

The importmap contains something like this (thanks to #39):

```
# host_app/vendor/assets/javascripts/importmap.js.erb

{
  "imports": {
    <%= importmap_list_with_stimulus_from(
      MyGem::Engine.root.join("app/assets/javascripts/controllers"),
      MyGem::Engine.root.join("app/assets/javascripts/libraries"),
    ) %>
  }
}
```
Of course, the importmap is being added to the list of things to precompile in the gem's manifest

```
# my_gem/app/assets/config/my_gem_manifest.js

....
//= link importmap.json
```

This works correctly, the importmap is loaded and contains the right assets but not being able to change the importmap path, **prevents the host application to have its own importmap**; as it is now they both should be accessible by the helper at the same path (`/importmap.json.erb`).

With this proposed change, we can easily move the gem's importmap at `host_app/vendor/assets/javascripts/my_gem/importmap.js.erb`, add it to the manifest as:

```
# my_gem/app/assets/config/my_gem_manifest.js

....
//= link my_gem/importmap.json
```

and reference to it without collisions as:

```erb
# my_gem/app/views/layouts/application.html.erb

<head>
  <%= stimulus_include_tags("my_gem/importmap.json") %>
  ...
</head>
```
