### PR TITLE
Remove compact_blank usage

### DIFF
--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -1,6 +1,6 @@
 module Stimulus::ImportmapHelper
   def importmap_list_with_stimulus_from(*paths)
-    [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ].compact_blank.join(",\n")
+    [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ].reject(&:blank?).join(",\n")
   end
 
   def importmap_list_from(*paths)


### PR DESCRIPTION
This method [has been added in Rails 6.1](https://github.com/rails/rails/commit/c8847c17a7c9ae75c44c522c56ccd9c5fca25ea7) and stimulus-rails is also compatible with Rails 6.0, as its [gemspec](https://github.com/hotwired/stimulus-rails/blob/3611362a7179b21c9f28657b7b2085e5bf6f7909/stimulus-rails.gemspec#L17) tells.