### PR TITLE
Standard Library of ARIA controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "turbo-rails", github: "hotwired/turbo-rails", branch: "main"
 
 group :test do
   gem "capybara"
+  gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors", branch: "main"
   gem "selenium-webdriver"
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/citizensadvice/capybara_accessible_selectors.git
+  revision: d61971c609e3b019df6dc0ea0c9ce11433f3d0f7
+  branch: main
+  specs:
+    capybara_accessible_selectors (0.4.1)
+      capybara (~> 3)
+
+GIT
   remote: https://github.com/hotwired/turbo-rails.git
   revision: 551890dba1aa23f1a84be77820f96a458723f1a9
   branch: main
@@ -173,6 +181,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  capybara_accessible_selectors!
   selenium-webdriver
   sqlite3
   stimulus-rails!

--- a/app/assets/javascripts/stimulus/controllers/aria/dialog_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/aria/dialog_controller.js
@@ -1,0 +1,102 @@
+import dialogPolyfill from "https://cdn.skypack.dev/dialog-polyfill"
+import wicgInert from "https://cdn.skypack.dev/wicg-inert"
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  initialize() {
+    dialogPolyfill.registerDialog(this.element)
+    this.observer = new MutationObserver(() => {
+      this.element.open ? this.showModal() : this.close()
+    })
+  }
+
+  connect() {
+    this.element.setAttribute("role", "dialog")
+    this.element.setAttribute("aria-modal", "true")
+
+    if (this.element.open) {
+      this.element.open = false
+      this.showModal()
+    }
+    this.observeMutationsToOpen()
+  }
+
+  disconnect() {
+    this.observer.disconnect()
+  }
+
+  showModal() {
+    this.trapFocus()
+    this.ensureDialogIsLabelled()
+    this.withoutObservingMutations(() => {
+      this.element.open = false
+      this.element.showModal()
+    })
+    this.focusFirstInteractiveElement()
+  }
+
+  close() {
+    this.withoutObservingMutations(() => {
+      this.element.open = true
+      this.element.close()
+      this.releaseFocus()
+    })
+  }
+
+  // Private
+
+  ensureDialogIsLabelled = () => {
+    if (this.element["aria-labelledby"] || this.element["aria-label"]) return
+
+    const heading = this.element.querySelector("h1, h2, h3, h4, h5, h6")
+
+    if (heading) {
+      this.element.addEventListener("close", this.removeDialogLabel, { once: true })
+
+      if (heading.id) {
+        this.element.setAttribute("aria-labelledby", heading.id)
+      } else {
+        this.element.setAttribute("aria-label", heading.textContent.trim())
+      }
+    }
+  }
+
+  removeDialogLabel = () => {
+    this.element.removeAttribute("aria-labelledby")
+    this.element.removeAttribute("aria-label")
+  }
+
+  trapFocus = () => {
+    this.lastElementWithFocus = document.activeElement
+    this.siblingElements.forEach(element => element.inert = true)
+  }
+
+  releaseFocus = () => {
+    this.siblingElements.forEach(element => element.inert = false)
+    this.lastElementWithFocus?.isConnected && this.lastElementWithFocus.focus()
+
+    delete this.lastElementWithFocus
+  }
+
+  focusFirstInteractiveElement = () => {
+    const visibleElements = [ ...this.element.querySelectorAll("*:not([hidden]):not([type=hidden])") ]
+    const firstInteractiveElement = visibleElements.find(({ tabIndex }) => tabIndex > -1)
+
+    firstInteractiveElement?.focus()
+  }
+
+
+  observeMutationsToOpen() {
+    this.observer.observe(this.element, { attributeFilter: ["open"] })
+  }
+
+  withoutObservingMutations(callback) {
+    this.observer.disconnect()
+    callback()
+    this.observeMutationsToOpen()
+  }
+
+  get siblingElements() {
+    return [ ...this.element.parentElement.children ].filter(element => element != this.element)
+  }
+}

--- a/app/assets/javascripts/stimulus/controllers/aria/expander_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/aria/expander_controller.js
@@ -1,0 +1,85 @@
+import dialogPolyfill from "https://cdn.skypack.dev/dialog-polyfill"
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static get classes() {
+    return [ "toggle" ]
+  }
+
+  initialize() {
+    this.elementStateObserver = new MutationObserver(this.pullStateFromElement)
+    this.attributesObserver = new MutationObserver(() => {
+      this.elementObserver.disconnect()
+      this.elementObserver.observe(this.controlsElement, { attributeFilter: ["open"] })
+    })
+  }
+
+  connect() {
+    if (this.element.hasAttribute("aria-expanded")) {
+      this.pushStateToElement(this.expanded)
+    } else {
+      this.pullStateFromElement()
+    }
+    this.attributesObserver.observe(this.element, { attributeFilter: ["aria-controls"] })
+    this.elementStateObserver.observe(this.controlsElement, { attributeFilter: ["open"] })
+  }
+
+  disconnect() {
+    this.attributesObserver.disconnect()
+    this.elementStateObserver.disconnect()
+  }
+
+  toggle() {
+    this.element.focus()
+    this.expanded = !this.expanded
+  }
+
+  // Private
+
+  pushStateToElement = (expanded) => {
+    if (this.hasToggleClass) {
+      this.controlsElement.classList.toggle(this.toggleClass, expanded)
+    } else if ("open" in this.controlsElement) {
+      this.controlsElement.open = expanded
+    } else {
+      this.controlsElement.hidden = !expanded
+    }
+  }
+
+  pullStateFromElement = () => {
+    let isExpanded = false
+    if (this.hasToggleClass) {
+      isExpanded = this.controlsElement.classList.contains(this.toggleClass)
+    } else if ("open" in this.controlsElement) {
+      isExpanded = this.controlsElement.open
+    } else {
+      isExpanded = !this.controlsElement.hidden
+    }
+
+    this.element.setAttribute("aria-expanded", isExpanded)
+  }
+
+  set expanded(expanded) {
+    this.element.setAttribute("aria-expanded", expanded)
+    this.pushStateToElement(expanded)
+  }
+
+  get expanded() {
+    return this.element.getAttribute("aria-expanded") == "true"
+  }
+
+  get controlsElement() {
+    const id = this.element.getAttribute("aria-controls")
+    const element = document.getElementById(id)
+
+    if (/dialog/i.test(element.tagName)) {
+      dialogPolyfill.registerDialog(element)
+    }
+
+    return element
+  }
+}
+
+function setAttribute(element, value) {
+  return () => element.setAttribute("aria-expanded", value)
+}

--- a/app/assets/javascripts/stimulus/controllers/aria/feed_controller.js
+++ b/app/assets/javascripts/stimulus/controllers/aria/feed_controller.js
@@ -1,0 +1,59 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  initialize() {
+    this.observer = new MutationObserver(this.refreshArticles)
+  }
+
+  connect() {
+    this.refreshArticles()
+    this.observer.observe(this.element, { childList: true })
+  }
+
+  disconnect() {
+    this.observer.disconnect()
+  }
+
+  navigate({ ctrlKey, key, target } = event) {
+    const article = this.articleElements.find(element => element.contains(target))
+    const index = this.articleElements.indexOf(article)
+    const firstIndex = 0
+    const lastIndex = this.articleElements.length - 1
+    let nextArticle
+
+    switch (key) {
+      case "PageUp":
+        nextArticle = this.articleElements[Math.max(firstIndex, index - 1)]
+        break
+      case "PageDown":
+        nextArticle = this.articleElements[Math.min(lastIndex, index + 1)]
+        break
+      case "Home":
+        if (ctrlKey) nextArticle = this.articleElements[firstIndex]
+        break
+      case "End":
+        if (ctrlKey) nextArticle = this.articleElements[lastIndex]
+        break
+    }
+
+    if (nextArticle) {
+      event.preventDefault()
+      nextArticle.focus()
+    }
+  }
+
+  refreshArticles = () => {
+    this.element.setAttribute("aria-setsize", this.articleElements.length + 1)
+
+    this.articleElements.forEach((element, index) => {
+      element.setAttribute("tabindex", 0)
+      element.setAttribute("aria-posinset", index + 1)
+    })
+  }
+
+  // Private
+
+  get articleElements() {
+    return [ ...this.element.querySelectorAll("* > article, * > [role=article]") ]
+  }
+}

--- a/app/assets/javascripts/stimulus/manifest.js
+++ b/app/assets/javascripts/stimulus/manifest.js
@@ -1,2 +1,3 @@
+//= link_directory ./controllers
 //= link_directory ./libraries
 //= link_directory ./loaders

--- a/lib/stimulus/importmap_helper.rb
+++ b/lib/stimulus/importmap_helper.rb
@@ -1,6 +1,10 @@
 module Stimulus::ImportmapHelper
   def importmap_list_with_stimulus_from(*paths)
-    [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_list_from(*paths) ].reject(&:blank?).join(",\n")
+    [
+      %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"),
+      importmap_list_from_standard_controllers,
+      importmap_list_from(*paths)
+    ].reject(&:blank?).join(",\n")
   end
 
   def importmap_list_from(*paths)
@@ -14,6 +18,18 @@ module Stimulus::ImportmapHelper
           %("#{module_name}": "#{module_path}")
         end
       end
+    end.compact.join(",\n")
+  end
+
+  def importmap_list_from_standard_controllers
+    stimulus_root = Pathname(__dir__).join("../../app/assets/javascripts/stimulus/controllers")
+
+    stimulus_root.glob("**/*.js").collect do |absolute_path|
+      module_filename = absolute_path.relative_path_from(stimulus_root)
+      module_name     = importmap_module_name_from(module_filename)
+      module_path     = asset_path("stimulus/controllers/#{module_filename}")
+
+      %("#{module_name}": "#{module_path}")
     end.compact.join(",\n")
   end
 

--- a/test/dummy/app/controllers/aria/examples_controller.rb
+++ b/test/dummy/app/controllers/aria/examples_controller.rb
@@ -1,0 +1,4 @@
+module Aria
+  class ExamplesController < ApplicationController
+  end
+end

--- a/test/dummy/app/views/aria/examples/index.html.erb
+++ b/test/dummy/app/views/aria/examples/index.html.erb
@@ -1,0 +1,67 @@
+<% content_for :head do %>
+  <style>
+    dialog        { display: none; }
+    dialog[open]  { display: block; }
+  </style>
+<% end %>
+
+
+<button aria-expanded="false" aria-controls="dialog" type="button" data-controller="aria--expander" data-action="click->aria--expander#toggle">
+  Open Dialog
+</button>
+
+<dialog id="dialog" data-controller="aria--dialog">
+  <h1 id="dialog-title">Modal Dialog</h1>
+
+  <form>
+    <label for="first_input">First input</label>
+    <input id="first_input" type="text">
+
+    <input type="hidden">
+
+    <label for="second_input">Second input</label>
+    <input id="second_input" type="text">
+
+    <label for="third_input">Third input</label>
+    <input id="third_input" type="text">
+
+    <button type="submit" formmethod="dialog">Cancel</button>
+    <button type="submit">Submit</button>
+  </form>
+</dialog>
+
+<button type="button">Inert Button</button>
+
+<hr>
+
+<button aria-expanded="false" aria-controls="details" type="button" data-controller="aria--expander" data-action="click->aria--expander#toggle">
+  Open Details
+</button>
+
+<details id="details">
+  <summary>Summary</summary>
+
+  Details
+</details>
+
+<button aria-expanded="false" aria-controls="css-class" type="button" data-controller="aria--expander" data-aria--expander-toggle-class="expanded" data-action="click->aria--expander#toggle">
+  Toggle CSS class
+</button>
+
+<div id="css-class">CSS class</div>
+
+<button aria-controls="hidden" type="button" data-controller="aria--expander" data-action="click->aria--expander#toggle">
+  Toggle Hidden
+</button>
+
+<div id="hidden">Visible</div>
+
+<hr>
+
+<a href="#feed">Skip to #feed</a>
+
+<div role="feed" id="feed" data-controller="aria--feed" data-action="keydown->aria--feed#navigate">
+  <article>First article</article>
+  <article>Second article</article>
+  <article>Third article</article>
+</div>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,5 +3,9 @@ Rails.application.routes.draw do
   get "/no_controllers/turbo" => "application#turbo", as: :turbo
   get "/no_controllers" => "application#no_controllers", as: :no_controllers
 
+  namespace :aria do
+    resources :examples, only: :index
+  end
+
   root to: "application#index"
 end

--- a/test/stimulus_test.rb
+++ b/test/stimulus_test.rb
@@ -33,14 +33,49 @@ class StimulusTest < ActionView::TestCase
     JSON
   end
 
+  test "importmap_list_from_standard_controller loads Stimulus stdlib files" do
+    assert_json_equal <<~JSON.strip, importmap_list_from_standard_controllers
+      "aria/dialog_controller": "/stimulus/controllers/aria/dialog_controller.js",
+      "aria/feed_controller": "/stimulus/controllers/aria/feed_controller.js",
+      "aria/expander_controller": "/stimulus/controllers/aria/expander_controller.js"
+    JSON
+  end
+
+  test "importmap_list_with_stimulus_from helper loads stimulus alongside dependent controllers" do
+    assert_json_equal <<~JSON.strip, importmap_list_with_stimulus_from("app/assets/javascripts/controllers")
+      "stimulus": "/stimulus/libraries/stimulus",
+      "aria/dialog_controller": "/stimulus/controllers/aria/dialog_controller.js",
+      "aria/feed_controller": "/stimulus/controllers/aria/feed_controller.js",
+      "aria/expander_controller": "/stimulus/controllers/aria/expander_controller.js",
+      "hello_controller": "/controllers/hello_controller.js",
+      "loading_controller": "/controllers/loading_controller.js",
+      "namespace/message_rendering_controller": "/controllers/namespace/message_rendering_controller.js",
+      "message_rendering_controller": "/controllers/message_rendering_controller.js"
+    JSON
+  end
+
   test "import map list helper with nothing to load" do
     assert_json_equal <<~JSON.strip, importmap_list_with_stimulus_from("app/components")
-      "stimulus": "/stimulus/libraries/stimulus"
+      "stimulus": "/stimulus/libraries/stimulus",
+      "aria/dialog_controller": "/stimulus/controllers/aria/dialog_controller.js",
+      "aria/feed_controller": "/stimulus/controllers/aria/feed_controller.js",
+      "aria/expander_controller": "/stimulus/controllers/aria/expander_controller.js"
+    JSON
+  end
+
+  test "importmap_list_with_stimulus_from helper can load stimulus stdlib controllers" do
+    assert_json_equal <<~JSON.strip, importmap_list_with_stimulus_from("app/assets/javascripts/stimulus/controllers")
+      "stimulus": "/stimulus/libraries/stimulus",
+      "aria/dialog_controller": "/stimulus/controllers/aria/dialog_controller.js",
+      "aria/feed_controller": "/stimulus/controllers/aria/feed_controller.js",
+      "aria/expander_controller": "/stimulus/controllers/aria/expander_controller.js"
     JSON
   end
 
   private
     def assert_json_equal(expected, actual)
       assert_equal JSON.parse("{ #{expected} }"), JSON.parse("{ #{actual} }")
+    rescue JSON::ParserError => e
+      flunk "expected both { #{expected.squish} } and { #{actual.squish} } to be valid JSON"
     end
 end

--- a/test/system/aria/dialog_controller_test.rb
+++ b/test/system/aria/dialog_controller_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class Aria::DialogControllerTest < ApplicationSystemTestCase
+  test "dialog is focus-trapping modal" do
+    visit aria_examples_path
+    sleep 1
+
+    click_button("Open Dialog")
+    within_modal "Modal Dialog" do
+      assert_field "First input", focused: true
+
+      send_keys([:shift, :tab]).then    { assert_no_button "Open Dialog", focused: true }
+      2.times { send_keys(:tab) }.then  { assert_field "Second input", focused: true }
+      send_keys(:tab).then              { assert_field "Third input", focused: true }
+      send_keys(:tab).then              { assert_button "Cancel", focused: true }
+      send_keys(:tab).then              { assert_button "Submit", focused: true }
+      send_keys(:tab).then              { assert_no_button "Skipped in tab order", focused: true }
+    end
+    send_keys(:escape).then             { assert_button "Open Dialog", focused: true }
+  end
+
+  test "cancel button closes the dialog and restores focus to the expander" do
+    visit aria_examples_path
+    sleep 1
+
+    click_button "Open Dialog"
+    within_modal "Modal Dialog" do
+      click_button("Cancel")
+    end
+
+    assert_button "Open Dialog", focused: true
+  end
+end

--- a/test/system/aria/expander_controller_test.rb
+++ b/test/system/aria/expander_controller_test.rb
@@ -1,0 +1,36 @@
+require "application_system_test_case"
+
+class Aria::ExpanderControllerTest < ApplicationSystemTestCase
+  test "expander toggles <details>" do
+    visit aria_examples_path
+    sleep 1
+
+    assert_selector :disclosure_button, "Open Details", expanded: false
+
+    toggle_disclosure("Open Details").then  { assert_selector :disclosure, text: "Details", expanded: true }
+    toggle_disclosure("Open Details").then  { assert_selector :disclosure, text: "Details", expanded: false }
+    toggle_disclosure("Summary").then       { assert_selector :disclosure_button, "Open Details", expanded: true }
+  end
+
+  test "expander toggles CSS class" do
+    visit aria_examples_path
+    sleep 1
+
+    assert_no_selector "#css-class.expanded", text: "CSS class"
+    assert_selector :disclosure_button, "Toggle CSS class", expanded: false
+
+    click_on("Toggle CSS class").then { assert_selector "#css-class.expanded", text: "CSS class" }
+    click_on("Toggle CSS class").then { assert_no_selector "#css-class.expanded", text: "CSS class" }
+  end
+
+  test "expander toggles hidden" do
+    visit aria_examples_path
+    sleep 1
+
+    assert_text "Visible"
+    assert_selector :disclosure_button, "Toggle Hidden", expanded: false
+
+    click_on("Toggle Hidden").then { assert_no_text "Visible" }
+    click_on("Toggle Hidden").then { assert_text "Visible" }
+  end
+end

--- a/test/system/aria/feed_controller_test.rb
+++ b/test/system/aria/feed_controller_test.rb
@@ -1,0 +1,28 @@
+require "application_system_test_case"
+
+class Aria::FeedControllerTest < ApplicationSystemTestCase
+  test "articles in the feed can be navigated with the keyboard" do
+    visit aria_examples_path
+    sleep 1
+
+    click_on("Skip to #feed")
+    send_keys(:tab).then              { assert_selector "article", text: "First article", focused: true }
+    send_keys(:page_down).then        { assert_selector "article", text: "Second article", focused: true }
+    send_keys([:control, :end]).then  { assert_selector "article", text: "Third article", focused: true }
+    send_keys(:page_up).then          { assert_selector "article", text: "Second article", focused: true }
+    send_keys([:control, :home]).then { assert_selector "article", text: "First article", focused: true }
+
+    append_article("Fourth article", into: "feed")
+
+    send_keys([:control, :end]).then   { assert_selector "article", text: "Fourth article", focused: true }
+  end
+
+  private
+
+    def append_article(text, into:)
+      execute_script <<~JS, into, text
+        const [ id, text] = arguments
+        document.getElementById(id).insertAdjacentHTML("beforeend", `<article>${text}</article>`)
+      JS
+    end
+end


### PR DESCRIPTION
Inspired by [Experiment with a standard library of
controllers][stdlib-pr], introduce some Stimulus controllers that
implement keyboard interactions for ARIA patterns in accordance with
their specifications.

While the stimulus-rails repository might not be the ultimate
destination for code like this, being a Rails engine makes it possible
for the JavaScript controllers to be covered by Selenium-powered
Sysytem Tests, and provides an opportunity to be published alongside
corresponding Rails View Helpers, Capybara selectors, and System Test
assertions and helpers.

Ultimately, maybe the controller source code can be published alongside
`hotwired/stimulus`, and the View Helpers, Selectors, and System Test
methods can remain in this gem.

[stdlib-pr]: https://github.com/hotwired/stimulus-rails/pull/24

aria--expander
---

Opens `<dialog>` and `<details>` elements, toggles the
`aria--expander-toggle-class` when provided, and falls back to toggling
the `[hidden]` attribute for all other circumstances.

aria--dialog
---

While the `<dialog>` element serves as a foundation, there are
[additional considerations to the ARIA specifications for
role="dialog"][role="dialog"]. For example, role="dialog" elements are
required to needs to trap focus navigation to interactive elements
within:

> Like non-modal dialogs, modal dialogs contain their tab sequence. That
> is, <kbd>Tab</kbd> and <kbd>Shift + Tab</kbd> do not move focus
> outside the dialog. However, unlike most non-modal dialogs, modal
> dialogs do not provide means for moving keyboard focus outside the
> dialog window without closing the dialog.
>
> When a dialog opens, focus moves to an element inside the dialog. See
> notes below regarding initial focus placement.
>
> It is strongly recommended that the tab sequence of all dialogs
> include a visible element with role button that closes the dialog,
> such as a close icon or cancel button.

The additional behavior covering this is implemented within the
`aria--dialog` controller, which supports the `<dialog>` element.

[dialog]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
[role="dialog"]: https://www.w3.org/TR/wai-aria-practices/#dialog_modal

aria--feed
---

Navigates focus across [role="article"] or `<article>` descendants of a
container element annotated with [role="feed"][]:

> A feed is a section of a page that automatically loads new sections of
> content as the user scrolls. The sections of content in a feed are
> presented in article elements. So, a feed can be thought of as a dynamic
> list of articles that often appears to scroll infinitely.

[role="feed"]: https://www.w3.org/TR/wai-aria-practices/#feed