### PR TITLE
Add initial support for Sprockets directives to generate and compose importmaps

### DIFF
--- a/lib/stimulus/directive_processor.rb
+++ b/lib/stimulus/directive_processor.rb
@@ -1,0 +1,86 @@
+module Stimulus
+  class DirectiveProcessor < Sprockets::DirectiveProcessor
+    def call(input)
+      @input = input
+      @environment = @input[:environment]
+      @imports = {}
+      @scopes = {}
+      output = super(@input)
+      process_input_importmap(output[:data])
+      output.merge(data: output_importmap)
+    end
+
+    def process_map_directive(path)
+      @imports.merge!(asset_map(path))
+    end
+
+    def process_map_directory_directive(path = ".", accept = nil)
+      path = expand_relative_dirname(:map_directory, path)
+      accept = expand_accept_shorthand(accept)
+      resolve_paths(*@environment.stat_directory_with_dependencies(path), accept: accept) do |uri|
+        @imports.merge!(asset_map(uri))
+      end
+    end
+
+    def process_map_tree_directive(path = ".", accept = nil)
+      path = expand_relative_dirname(:map_tree, path)
+      accept = expand_accept_shorthand(accept)
+      resolve_paths(*@environment.stat_sorted_tree_with_dependencies(path), accept: accept) do |uri|
+        @imports.merge!(asset_map(uri))
+      end
+    end
+
+    private
+
+    def process_input_importmap(input)
+      return unless input.present?
+      json = ActiveSupport::JSON.decode(input)
+      raise Sprockets::ContentTypeMismatch, "invalid importmap supplied" unless json.is_a? Hash
+      @imports.merge!(json["imports"].to_h)
+      @scopes.deep_merge!(json.except("imports").to_h)
+    end
+
+    def output_importmap
+      ActiveSupport::JSON.encode({ "imports" => @imports }.merge(@scopes))
+    end
+
+    def asset_map(path)
+      logical_path = @environment.find_asset!(resolve(path)).to_hash[:name]
+      { logical_path => @environment.context_class.new(@input).asset_path(logical_path) }
+    end
+
+    def resolve(path, **kwargs)
+      raise Sprockets::FileOutsidePaths, "can't require absolute file: #{path}" if @environment.absolute_path?(path)
+      uri, deps = @environment.resolve!(path, **kwargs.merge(base_path: @dirname))
+      @dependencies.merge(deps)
+      uri
+    end
+
+    def resolve_paths(paths, deps, **kwargs)
+      @dependencies.merge(deps)
+      paths.each do |subpath, stat|
+        next if subpath == @filename || stat.directory?
+        uri, deps = @environment.resolve(subpath, **kwargs)
+        @dependencies.merge(deps)
+        yield uri if uri
+      end
+    end
+
+    def expand_relative_dirname(directive, path)
+      raise Sprockets::ArgumentError, "#{directive} argument must be a relative path" unless @environment.relative_path?(path)
+      path = File.expand_path(path, @dirname)
+      stat = @environment.stat(path)
+      raise Sprockets::ArgumentError, "#{directive} argument must be a directory" unless stat.try(:directory?)
+      path
+    end
+
+    def expand_accept_shorthand(accept)
+      case accept
+        when nil then nil
+        when /\// then accept
+        when /^\./ then @environment.mime_exts[accept]
+        else @environment.mime_exts[".#{accept}"]
+      end
+    end
+  end
+end

--- a/lib/stimulus/engine.rb
+++ b/lib/stimulus/engine.rb
@@ -4,6 +4,19 @@ module Stimulus
   class Engine < ::Rails::Engine
     config.autoload_once_paths = %w( #{root}/app/helpers )
 
+    if const_defined? :Sprockets
+      require "stimulus/directive_processor"
+
+      Sprockets.register_mime_type "application/importmap+json", extensions: ['.json.importmap']
+      Sprockets.register_preprocessor "application/importmap+json", DirectiveProcessor.new(comments: ["//", ["/*", "*/"]])
+      Sprockets.register_bundle_processor "application/importmap+json", Sprockets::Bundle
+      Sprockets.register_bundle_metadata_reducer "application/importmap+json", :data, proc { +"{}" } do |buffer, source|
+        buffer_json = ActiveSupport::JSON.decode(buffer)
+        source_json = ActiveSupport::JSON.decode(source)
+        ActiveSupport::JSON.encode(buffer_json.deep_merge(source_json))
+      end
+    end
+
     initializer "stimulus.assets" do
       Rails.application.config.assets.precompile += %w( importmap.json stimulus/manifest )
     end

--- a/test/stimulus/directive_processor_test.rb
+++ b/test/stimulus/directive_processor_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Stimulus
+  class DirectiveProcessorTest < ActionView::TestCase
+    test "map directive adds asset to importmap" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: "//= map controllers/hello_controller\n//= map controllers/loading_controller",
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"#{asset_path("controllers/hello_controller")}","controllers/loading_controller":"#{asset_path("controllers/loading_controller")}"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+
+    test "map directory directive adds assets to importmap" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: "//= map_directory ./controllers",
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"#{asset_path("controllers/hello_controller")}","controllers/loading_controller":"#{asset_path("controllers/loading_controller")}","controllers/message_rendering_controller":"#{asset_path("controllers/message_rendering_controller")}","controllers/not_js":"#{asset_path("controllers/not_js")}"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+
+    test "map directory directive with accept adds assets to importmap" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: "//= map_directory ./controllers .js",
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"#{asset_path("controllers/hello_controller")}","controllers/loading_controller":"#{asset_path("controllers/loading_controller")}","controllers/message_rendering_controller":"#{asset_path("controllers/message_rendering_controller")}"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+
+    test "map tree directive with accept adds assets to importmap" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: "//= map_tree ./controllers .js",
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"#{asset_path("controllers/hello_controller")}","controllers/loading_controller":"#{asset_path("controllers/loading_controller")}","controllers/message_rendering_controller":"#{asset_path("controllers/message_rendering_controller")}","controllers/namespace/message_rendering_controller":"#{asset_path("controllers/namespace/message_rendering_controller")}"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+
+    test "map directive adds asset to static importmap" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: %Q(//= map controllers/hello_controller\n//= map controllers/loading_controller\n{"imports":{"foo":"bar"}}),
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"#{asset_path("controllers/hello_controller")}","controllers/loading_controller":"#{asset_path("controllers/loading_controller")}","foo":"bar"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+
+    test "static importmap overrides map directives" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: %Q(//= map controllers/hello_controller\n//= map controllers/loading_controller\n{"imports":{"controllers/hello_controller":"bar"}}),
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"bar","controllers/loading_controller":"#{asset_path("controllers/loading_controller")}"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+
+    test "handles scopes in static importmap" do
+      environment = Sprockets::Environment.new(Rails.root)
+      environment.append_path("app/assets/javascripts")
+      environment.context_class.class_eval do
+        include ActionView::Helpers::AssetUrlHelper
+      end
+      input = {
+        environment: environment,
+        filename: "test/dummy/app/assets/javascripts/foo.json.importmap",
+        content_type: 'application/importmap+json',
+        data: %Q(//= map controllers/hello_controller\n{"imports":{},"foo":{"bar":"baz"}}),
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      output = %Q({"imports":{"controllers/hello_controller":"#{asset_path("controllers/hello_controller")}"},"foo":{"bar":"baz"}})
+      assert_equal output, DirectiveProcessor.call(input)[:data]
+    end
+  end
+end


### PR DESCRIPTION
This PR is intended to address issues raised in #47, in particular being able to use relative paths to specify assets in engines, and being able to compose importmaps. The main idea is that by integrating more tightly with Sprockets (for apps that use Sprockets), a lot of the difficulties with engines can be solved relatively cleanly because Sprockets already supports assets within Engines, and is very extensible.

This PR allows generating importmaps by creating assets with a `.json.importmap` extension (corresponding to `application/importmap+json` as per the [draft spec](https://wicg.github.io/import-maps)). In these files you can use new directives to generate the importmap. All of the directives find the assets using Sprockets, and from this get the logical path of the asset (e.g. `some/asset` for `app/assets/javascripts/some/asset.js`) and the real asset path (e.g. `/assets/some/asset-[DIGEST].js`). Because of this, the assets can be in any Sprockets load path (e.g. in `app/assets` for the main app, in an engine, in `lib/assets` or `vendor/assets`, or whatever else is added to the load paths). The logical paths and real paths are then used to generate the importmap so that logical paths map to real paths. This is importantly different to the current behaviour, where the paths passed to the existing importmap helper are treated as roots—the autoloader and existing importmap helper would need to be changed to avoid having to add a `controllers--` prefix to `data-controller` for a controller in e.g. `app/javascripts/controllers`. But this new behaviour means that there can be no file path collisions in the generated importmap that are not already a problem for Sprockets. This PR also resolves #54.

### Directives

`map` maps a single asset, like `link` and `require`:
``` js
//= map some_asset
```
`map_directory` maps the immediate child assets of a directory (and like `link_directory` an extension or content type can be supplied to narrow the search):
``` js
//= map_directory ./some_dir
//= map_directory ./some_dir .js
```
`map_tree` works the same way but maps all child assets  assets of a directory:
``` js
//= map_tree ./some_dir
//= map_tree ./some_dir .js
```

### Static importmaps

The importmap file can still contain a static importmap. This would be useful where extra assets not processed by Sprockets need to be mapped, custom mappings need to be specified, or scopes are used. The `DirectiveProcessor` first processes the custom directives above, and then merges in the parsed static importmap.

### Bundling

Standard Sprockets directives such as `link` and `require` can also be used. Unlike Javascript and CSS assets, importmaps are not concatenated when `require`d, instead the requiring importmap is deep merged with the required importmap. This means that apps and engines which need to pull in an existing importmap from an engine can do so in a way parallel to how asset manifests are linked. Or if separate importmaps are desired, they can just be `link`ed in the asset manifest.
``` js
// app_importmap.json.importmap
//
//= require my_engine/some_importmap
```