### PR TITLE
Make autoloading changes visible to the DOM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -180,4 +182,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.2.5
+   2.2.12

--- a/test/dummy/app/assets/javascripts/controllers/hello_controller.js
+++ b/test/dummy/app/assets/javascripts/controllers/hello_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
+  static get targets() { return [ "input", "output" ] }
+
+  greet() {
+    this.outputTarget.innerHTML = `Hello, ${this.inputTarget.value}`
   }
 }

--- a/test/dummy/app/assets/javascripts/controllers/namespace/message_rendering_controller.js
+++ b/test/dummy/app/assets/javascripts/controllers/namespace/message_rendering_controller.js
@@ -6,4 +6,8 @@ export default class extends Controller {
   connect() {
     this.element.innerHTML = `Namespace: ${this.messageValue}`
   }
+
+  sayHello() {
+    this.element.innerHTML = `Hello from Namespace: ${this.messageValue}`
+  }
 }

--- a/test/dummy/app/views/application/index.html.erb
+++ b/test/dummy/app/views/application/index.html.erb
@@ -5,6 +5,15 @@
   <%= tag.p "", data: { namespace__message_rendering_message_value: params[:message], controller: "
     namespace--message-rendering
   " } %>
+
+  <div data-controller="hello">
+    <input type="text" value="Waiting for Eager Load" data-hello-target="input">
+    <div data-hello-target="output"></div>
+
+    <button type="button" data-action="click->hello#greet">
+      Say Hello
+    </button>
+  </div>
 </section>
 
 <section id="load-attribute" data-controller="loading" data-loading-controller-value="message-rendering" data-message-rendering-message-value="<%= params[:message] %>">

--- a/test/system/autoload_test.rb
+++ b/test/system/autoload_test.rb
@@ -10,6 +10,16 @@ class AutoloadTest < ApplicationSystemTestCase
     end
   end
 
+  test "waits for autoloading to complete" do
+    visit root_path
+
+    within "#eager-loaded" do
+      click_button "Say Hello"
+
+      assert_text "Hello, Waiting for Eager Load"
+    end
+  end
+
   test "autoloads Controller modules on the page lazily" do
     visit root_path(message: "Hello World!")
 
@@ -44,5 +54,15 @@ class AutoloadTest < ApplicationSystemTestCase
       assert_text "Hello, from Turbo page"
       assert_text "Namespace: Hello, from Turbo page"
     end
+  end
+
+  def click_button(*)
+    begin
+      assert_css "[data-stimulus-autoloading]"
+    rescue
+      # does not eagerly load any Stimulus
+    end
+    assert_no_css "[data-stimulus-autoloading]"
+    super
   end
 end


### PR DESCRIPTION
Closes [#35][]
Related to [#49][]

Extend the autoloader to communicate autoloading state via
a [DOMTokenList][] stored in the `[data-stimulus-autoloading]`
attribute.

The goal is to communicate state to the DOM so that tools like Capybara
can monitor the presence or absence of the attribute, and synchronize
page interactions based on whether autoloading is in-flight. By waiting,
our System Tests can act with confidence that any lazily-loaded behavior
is ready.

[#35]: https://github.com/hotwired/stimulus-rails/issues/35
[#49]: https://github.com/hotwired/stimulus-rails/pull/49/files#r610601520
[DOMTokenList]: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList