### PR TITLE
Update mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -180,4 +182,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.2.5
+   2.2.12


### PR DESCRIPTION
Addresses failure in CI:

```
Fetching gem metadata from https://rubygems.org/............ Your bundle
is locked to mimemagic (0.3.5), but that version could not be found in
any of the sources listed in your Gemfile. If you haven't changed
sources, that means the author of mimemagic (0.3.5) has removed it.
You'll need to update your bundle to a version other than mimemagic
(0.3.5) that hasn't been removed in order to install.
```