### PR TITLE
Look for Typescript files when loading controllers

### DIFF
--- a/lib/install/app/assets/javascripts/controllers/index.js
+++ b/lib/install/app/assets/javascripts/controllers/index.js
@@ -1,9 +1,9 @@
 // Load all the controllers within this directory and all subdirectories. 
-// Controller files must be named *_controller.js.
+// Controller files must be named *_controller.js or *_controller.ts.
 
 import { Application } from "stimulus"
 import { definitionsFromContext } from "stimulus/webpack-helpers"
 
 const application = Application.start()
-const context = require.context("controllers", true, /_controller\.js$/)
+const context = require.context("controllers", true, /_controller\.(js|ts)$/)
 application.load(definitionsFromContext(context))


### PR DESCRIPTION
I created a Typescript controller and it was showing as successfully compiling in Webpacker logs but Stimulus was just ignoring its existence when I'd reference it with `data-controller` in the DOM. I made the attached change and Stimulus started using it.