### PR TITLE
Update the Hotwire subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stimulus for Rails
 
-[Stimulus](https://stimulus.hotwire.dev) is a JavaScript framework with modest ambitions. It doesn’t seek to take over your entire front-end in fact, it’s not concerned with rendering HTML at all. Instead, it’s designed to augment your HTML with just enough behavior to make it shine. Stimulus pairs beautifully with Turbo to provide a complete solution for fast, compelling applications with a minimal amount of effort.
+[Stimulus](https://stimulus.hotwired.dev) is a JavaScript framework with modest ambitions. It doesn’t seek to take over your entire front-end in fact, it’s not concerned with rendering HTML at all. Instead, it’s designed to augment your HTML with just enough behavior to make it shine. Stimulus pairs beautifully with Turbo to provide a complete solution for fast, compelling applications with a minimal amount of effort.
 
 Stimulus for Rails makes it easy to use this modest framework with the asset pipeline and ES6/ESM in the browser. It uses the 7kb es-module-shim to provide [importmap](https://github.com/WICG/import-maps) support for all ES6-compatible browsers. This means you can develop and deploy without using any bundling or transpiling at all! Far less complexity, no waiting for compiling.
 

--- a/stimulus-rails.gemspec
+++ b/stimulus-rails.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.version     = Stimulus::VERSION
   spec.authors     = [ "Sam Stephenson", "Javan Mahkmali", "David Heinemeier Hansson" ]
   spec.email       = "david@loudthinking.com"
-  spec.homepage    = "https://stimulus.hotwire.dev"
+  spec.homepage    = "https://stimulus.hotwired.dev"
   spec.summary     = "A modest JavaScript framework for the HTML you already have."
   spec.license     = "MIT"
 


### PR DESCRIPTION
`https://stimulus.hotwire.dev` → `https://stimulus.hotwired.dev`

As per: hotwired/hotwire-site@22a11ac