### PR TITLE
Rename Stimulus NPM package in hello controller for Webpacker users

### DIFF
--- a/lib/install/stimulus_with_webpacker.rb
+++ b/lib/install/stimulus_with_webpacker.rb
@@ -4,5 +4,8 @@ append_to_file "#{Webpacker.config.source_entry_path}/application.js", %(\nimpor
 say "Creating controllers directory"
 directory "#{__dir__}/app/assets/javascripts/controllers", "#{Webpacker.config.source_path}/controllers"
 
+say "Using Stimulus NPM package"
+gsub_file "#{Webpacker.config.source_path}/controllers/hello_controller.js", /@hotwired\//, ''
+
 say "Installing all Stimulus dependencies"
 run "yarn add stimulus"


### PR DESCRIPTION
This PR resolves the issue outlined in #66. For Webpacker users, Stimulus is still published on NPM under `"stimulus"` and so we need to remove the `@hotwired/` prefix from the package name for now.