### PR TITLE
🍡 Consitently kebab-case controller names in autoloaders

### DIFF
--- a/app/assets/javascripts/stimulus-importmap-autoloader.js
+++ b/app/assets/javascripts/stimulus-importmap-autoloader.js
@@ -6,7 +6,7 @@ const importmap = JSON.parse(document.querySelector("script[type=importmap]").te
 const importedControllerPaths = Object.keys(importmap.imports).filter((e) => e.match("controllers/"))
 
 importedControllerPaths.forEach(function(path) {
-  const name = path.replace("controllers/", "").replace("_controller", "").replace("/", "--").replace("_", "-")
+  const name = path.replace("controllers/", "").replace("_controller", "").replace("/", "--").replace(/_/g, "-")
 
   import(path)
     .then(module => application.register(name, module.default))


### PR DESCRIPTION
While transitioning a project from `webpacker` to `importmap-rails` I discovered a handful of my controllers weren't connecting. The root of the problem is that filenames are being transformed into registered controller names differently across `stimulus-autoloader` and `stimulus-importmap-autoloader`. This impacts controllers that have three or more words in their name.

```
# For example...
/app/assets/javascripts/controllers/many_much_words_controller.js

# Was being autloaded in the importmap solution as
many-much_words

# While the webpacker solution was autoloading as
many-much-words
```

This change makes it so that `stimulus-autoloader` and `stimulus-importmap-autoloader` consistently transform the filename, easing the transition for any other applications that might have a `really_long_and_descriptive_controller.js`.