### PR TITLE
Handle controller naming for view_components

### DIFF
--- a/app/assets/javascripts/stimulus-importmap-autoloader.js
+++ b/app/assets/javascripts/stimulus-importmap-autoloader.js
@@ -14,7 +14,7 @@ export function parseImportmapJson() {
 
 function registerControllerFromPath(path, under, application) {
   const name = path
-    .replace(`${under}/`, "")
+    .replace(new RegExp(`^${under}/`), "")
     .replace("_controller", "")
     .replace(/\//g, "--")
     .replace(/_/g, "-")


### PR DESCRIPTION
Currently, with sidecar view_components, the `HelloWorldComponent` will get a name of `hello-world-componenthello-world-component`. With this change, the resulting name will be `hello-world-component`.

This means we can now do
```
registerControllerFrom(".*_component", application)
```
to load all the stimulus controllers that I define for any view components.