### PR TITLE
Change attribute name to use dashes instead of underscore

### DIFF
--- a/lib/generators/stimulus/templates/controller.js.tt
+++ b/lib/generators/stimulus/templates/controller.js.tt
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="<%= @attribute.tr('_', '-') %>"
+// Connects to data-controller="<%= @attribute.tr("_", "-") %>"
 export default class extends Controller {
   connect() {
   }


### PR DESCRIPTION
As per the [naming convention](https://stimulus.hotwired.dev/reference/controllers#naming-conventions), "when an identifier is composed of more than one word, write the words in kebab-case"

People sometimes copy and paste (as I just did), and are probably wondering why their controller doesn't connect...