### PR TITLE
Change attribute string in generator method, not in template

### DIFF
--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -11,6 +11,6 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
 
   private
     def stimulus_attribute_value(name)
-      name.gsub(/\//, "--")
+      name.gsub(/\//, "--").gsub("_", "-")
     end
 end

--- a/lib/generators/stimulus/templates/controller.js.tt
+++ b/lib/generators/stimulus/templates/controller.js.tt
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="<%= @attribute.tr("_", "-") %>"
+// Connects to data-controller="<%= @attribute %>"
 export default class extends Controller {
   connect() {
   }


### PR DESCRIPTION
Sorry, I think a was a bit to quick to open a PR... while looking at the code again, I realized a better place to put that code would be in the generator, not in the template, as there is already a method called `stimulus_attribute_value` which changes the attribute string.

I was just about to change my PR, but it was already merged in... Sorry :worried:
