### PR TITLE
Improve Name Handling of Stimulus Generator

### DIFF
--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -4,13 +4,17 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
 
   def copy_view_files
-    @attribute = stimulus_attribute_value(name)
-    template "controller.js", "app/javascript/controllers/#{name}_controller.js"
+    @attribute = stimulus_attribute_value(controller_name)
+    template "controller.js", "app/javascript/controllers/#{controller_name}_controller.js"
     rails_command "stimulus:manifest:update" if Rails.root.join("package.json").exist?
   end
 
   private
-    def stimulus_attribute_value(name)
-      name.gsub(/\//, "--").gsub("_", "-")
+    def controller_name
+      name.underscore.gsub(/_controller$/, "")
+    end
+
+    def stimulus_attribute_value(controller_name)
+      controller_name.gsub(/\//, "--").gsub("_", "-")
     end
 end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+require "generators/stimulus/stimulus_generator"
+
+module Rails
+  def self.root
+    path = File.expand_path("../tmp", __dir__)
+
+    Pathname.new path
+  end
+end
+
+class StimulusGeneratorTest < Rails::Generators::TestCase
+  tests StimulusGenerator
+  destination Rails.root
+  setup :prepare_destination
+
+  test "generating a simple controller" do
+    run_generator ["hello"]
+
+    assert_file "app/javascript/controllers/hello_controller.js", /data-controller="hello"/
+  end
+
+  test "generating with camelized name" do
+    run_generator ["HelloWorld"]
+
+    assert_file "app/javascript/controllers/hello_world_controller.js", /data-controller="hello-world"/
+  end
+
+
+  test "generating with camelized name and lower case first letter" do
+    run_generator ["helloWorld"]
+
+    assert_file "app/javascript/controllers/hello_world_controller.js", /data-controller="hello-world"/
+  end
+
+  test "generating with kebab-cased name" do
+    run_generator ["hello-world"]
+
+    assert_file "app/javascript/controllers/hello_world_controller.js", /data-controller="hello-world"/
+  end
+
+  test "generating with underscored name" do
+    run_generator ["hello_world"]
+
+    assert_file "app/javascript/controllers/hello_world_controller.js", /data-controller="hello-world"/
+  end
+
+  test "generating with namespaced name" do
+    run_generator ["hello/world"]
+
+    assert_file "app/javascript/controllers/hello/world_controller.js", /data-controller="hello--world"/
+  end
+
+  test "generating with namespaced and camelized name" do
+    run_generator ["Hello/HappyWorld"]
+
+    assert_file "app/javascript/controllers/hello/happy_world_controller.js", /data-controller="hello--happy-world"/
+  end
+
+  test "generating with namespaced and camelized name with a lower case first letter" do
+    run_generator ["hello/happyWorld"]
+
+    assert_file "app/javascript/controllers/hello/happy_world_controller.js", /data-controller="hello--happy-world"/
+  end
+
+  test "generating with namespaced and kebab-cased name" do
+    run_generator ["hello/happy-world"]
+
+    assert_file "app/javascript/controllers/hello/happy_world_controller.js", /data-controller="hello--happy-world"/
+  end
+
+  test "generating with namespaced and underscored name" do
+    run_generator ["hello/happy_world"]
+
+    assert_file "app/javascript/controllers/hello/happy_world_controller.js", /data-controller="hello--happy-world"/
+  end
+
+  test "generating with ruby namespacing" do
+    run_generator ["Hello::RubyWorld"]
+
+    assert_file "app/javascript/controllers/hello/ruby_world_controller.js", /data-controller="hello--ruby-world"/
+  end
+
+  test "removes tailing 'controller'" do
+    run_generator ["HelloController"]
+
+    assert_file "app/javascript/controllers/hello_controller.js", /data-controller="hello"/
+  end
+
+  test "removes tailing 'controller' in namespaced string" do
+    run_generator ["Hello/WorldController"]
+
+    assert_file "app/javascript/controllers/hello/world_controller.js", /data-controller="hello--world"/
+  end
+
+end


### PR DESCRIPTION
The stimulus generator expects a much more restrictive naming convention compared to other rails-esqe generators such as `model` or `controller`.

When developing, I found myself copying strings from the ERB templates and pasting them into the command-line to generate a stimulus controller (like `rails generate stimulus hello-world`). Currently, the generator generates incorrect file names and data-attribute comments. In my example, the generator would create a `hello-world_controller.js` file. 

Today, this happened one too many times, so I created this PR. 

In essence, it uses `name.underscore` to normalize the controller name and then generates the appropriate data-attribute comment and file name. Additionally, it removes `_controller` suffixes from the name, which also got me several times ;) 