### PR TITLE
Use the same mapping as importmap

### DIFF
--- a/lib/stimulus/manifest.rb
+++ b/lib/stimulus/manifest.rb
@@ -15,7 +15,7 @@ module Stimulus::Manifest
 
     <<-JS
 
-import #{controller_class_name} from "./#{controller_path}"
+import #{controller_class_name} from "controllers/#{File.basename(controller_path, '.*')}"
 application.register("#{tag_name}", #{controller_class_name})
     JS
   end

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -40,7 +40,7 @@ namespace :stimulus do
         index.puts "// Run that command whenever you add a new controller or create them with"
         index.puts "// ./bin/rails generate stimulus controllerName"
         index.puts
-        index.puts %(import { application } from "./application")
+        index.puts %(import { application } from "controllers/application")
         index.puts manifest
       end
     end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -6,11 +6,11 @@ class Stimulus::Manifest::Test < ActiveSupport::TestCase
     manifest = Stimulus::Manifest.generate_from(file_fixture('controllers')).join
 
     # JavaScript controller
-    assert_includes manifest, 'import HelloController from "./hello_controller.js"'
+    assert_includes manifest, 'import HelloController from "controllers/hello_controller"'
     assert_includes manifest, 'application.register("hello", HelloController)'
 
     # CoffeeScript controller
-    assert_includes manifest, 'import CoffeeController from "./coffee_controller.coffee"'
+    assert_includes manifest, 'import CoffeeController from "controllers/coffee_controller"'
     assert_includes manifest, 'application.register("coffee", CoffeeController)'
   end
 end


### PR DESCRIPTION
This PR will make the changes proposed in #87 

Instead of using relative paths to reference the js files, it will use the reference given in the importmap.