### PR TITLE
Check for importmap configuration before updating manifest

### DIFF
--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -6,7 +6,7 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)
     template "controller.js", "app/javascript/controllers/#{controller_name}_controller.js"
-    rails_command "stimulus:manifest:update" if Rails.root.join("package.json").exist?
+    rails_command "stimulus:manifest:update" unless Rails.root.join("config/importmap.rb").exist?
   end
 
   private


### PR DESCRIPTION
Only run stimulus:manifest:update if (seemingly) not using importmaps. Resolves #87