### PR TITLE
replace hello controller with a show confirm example

### DIFF
--- a/lib/install/app/javascript/controllers/index_for_node.js
+++ b/lib/install/app/javascript/controllers/index_for_node.js
@@ -4,5 +4,5 @@
 
 import { application } from "./application"
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import ShowController from "./show_controller"
+application.register("show", ShowController)

--- a/lib/install/app/javascript/controllers/show_controller.js
+++ b/lib/install/app/javascript/controllers/show_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
+  confirm(event) {
+    if (!confirm('Are you sure?')) event.preventDefault();
   }
 }

--- a/lib/install/stimulus_with_importmap.rb
+++ b/lib/install/stimulus_with_importmap.rb
@@ -4,8 +4,8 @@ copy_file "#{__dir__}/app/javascript/controllers/index_for_importmap.js",
   "app/javascript/controllers/index.js"
 copy_file "#{__dir__}/app/javascript/controllers/application.js",
   "app/javascript/controllers/application.js"
-copy_file "#{__dir__}/app/javascript/controllers/hello_controller.js",
-  "app/javascript/controllers/hello_controller.js"
+copy_file "#{__dir__}/app/javascript/controllers/show_controller.js",
+  "app/javascript/controllers/show_controller.js"
 
 say "Import Stimulus controllers"
 append_to_file "app/javascript/application.js", %(import "controllers"\n)

--- a/lib/install/stimulus_with_node.rb
+++ b/lib/install/stimulus_with_node.rb
@@ -4,8 +4,8 @@ copy_file "#{__dir__}/app/javascript/controllers/index_for_node.js",
   "app/javascript/controllers/index.js"
 copy_file "#{__dir__}/app/javascript/controllers/application.js",
   "app/javascript/controllers/application.js"
-copy_file "#{__dir__}/app/javascript/controllers/hello_controller.js",
-  "app/javascript/controllers/hello_controller.js"
+copy_file "#{__dir__}/app/javascript/controllers/show_controller.js",
+  "app/javascript/controllers/show_controller.js"
 
 if (Rails.root.join("app/javascript/application.js")).exist?
   say "Import Stimulus controllers"

--- a/lib/stimulus/engine.rb
+++ b/lib/stimulus/engine.rb
@@ -5,5 +5,10 @@ module Stimulus
         Rails.application.config.assets.precompile += %w( stimulus.js stimulus.min.js stimulus.min.js.map )
       end
     end
+
+    initializer "stimulus.generator_templates" do
+      next unless Rails::VERSION::MAJOR >= 7
+      Rails.application.config.generators.templates.unshift(File.expand_path('../templates', __dir__))
+    end
   end
 end

--- a/lib/templates/erb/scaffold/show.html.erb.tt
+++ b/lib/templates/erb/scaffold/show.html.erb.tt
@@ -1,0 +1,10 @@
+<p style="color: green"><%%= notice %></p>
+
+<%%= render @<%= singular_table_name %> %>
+
+<div data-controller="show">
+  <%%= link_to "Edit this <%= human_name.downcase %>", <%= edit_helper(type: :path) %> %> |
+  <%%= link_to "Back to <%= human_name.pluralize.downcase %>", <%= index_helper(type: :path) %> %>
+
+  <%%= button_to "Destroy this <%= human_name.downcase %>", <%= model_resource_name(prefix: "@") %>, method: :delete, data: { action: "click->show#confirm" } %>
+</div>


### PR DESCRIPTION
The thought was to provide a more useful example, one that restores functionality present in Rails 6 and prior versions: a confirmation dialog.

This modifies the show template to reference a controller and an action that shows a confirmation dialog when destroying an instance of a scaffolded model.  People who create new projects are free to modify or even delete this example.

Note: no tests are provided as I have yet to figure out how to run initializers in tests, and by design the scaffolding will only be replaced for Rails 7 and up.  Pointers welcome, and if provided, I'll update this pull request.