### PR TITLE
Fix bug when mutation causes controller to be registered twice

### DIFF
--- a/app/assets/javascripts/stimulus-loading.js
+++ b/app/assets/javascripts/stimulus-loading.js
@@ -78,6 +78,8 @@ function controllerFilename(name, under) {
 }
 
 function registerController(name, module, application) {
-  application.register(name, module.default)
-  registeredControllers[name] = true
+  if (!(name in registeredControllers)) {
+    application.register(name, module.default)
+    registeredControllers[name] = true
+  }
 }


### PR DESCRIPTION
Partially reverts https://github.com/hotwired/stimulus-rails/commit/67e2cf3d419584628d7fe9b7857312ebd53d052e#diff-8e0a8f9875453f690405e8c037a8e76c4436f09f47fd9c605283c2f16bd95789L77

Resolves an issue where a controller is registered twice.

I created a sample Rails app to reproduce this issue. Relevant commit: https://github.com/lewispb/stimulus-loader-issue/commit/ce8aaa57a72473febd1b279847dc2fa33b859cee

To reproduce:

1. Insert a Turbo Stream element onto the page which in turn appends an element specifying a Stimulus controller
2. It appears the mutation observer triggers twice, once for the HTML element mutating (as the Turbo Stream element is inserted into the dom) and once for the append performed by the Turbo Stream action.
3. This triggers registering the Stimulus controller twice, and that has the effect of immediately disconnecting the controller

# Before

The first inserted element is removed as the disconnect function is immediately called. In our application this is a flash message.

https://user-images.githubusercontent.com/1773614/155033794-31ff5f99-4558-4df8-b674-d11304c9bc3d.mov

# After

Elements are removed correctly, after the timeout.

https://user-images.githubusercontent.com/1773614/155033810-2cc56dbe-6f29-4d06-9759-c99fbf5a7d93.mov

