### PR TITLE
Use stimulus router lookup table to decide if controller is registered

### DIFF
--- a/app/assets/javascripts/stimulus-loading.js
+++ b/app/assets/javascripts/stimulus-loading.js
@@ -2,7 +2,6 @@
 import "@hotwired/stimulus"
 
 const controllerAttribute = "data-controller"
-const registeredControllers = {}
 
 // Eager load all controllers registered beneath the `under` path in the import map to the passed application instance.
 export function eagerLoadControllersFrom(under, application) {
@@ -21,7 +20,7 @@ function registerControllerFromPath(path, under, application) {
     .replace(/\//g, "--")
     .replace(/_/g, "-")
 
-  if (!(name in registeredControllers)) {
+  if (canRegisterController(name, application)) {
     import(path)
       .then(module => registerController(name, module, application))
       .catch(error => console.error(`Failed to register controller: ${name} (${path})`, error))
@@ -66,7 +65,7 @@ function extractControllerNamesFrom(element) {
 }
 
 function loadController(name, under, application) {
-  if (!(name in registeredControllers)) {
+  if (canRegisterController(name, application)) {
     import(controllerFilename(name, under))
       .then(module => registerController(name, module, application))
       .catch(error => console.error(`Failed to autoload controller: ${name}`, error))
@@ -78,8 +77,11 @@ function controllerFilename(name, under) {
 }
 
 function registerController(name, module, application) {
-  if (!(name in registeredControllers)) {
+  if (canRegisterController(name, application)) {
     application.register(name, module.default)
-    registeredControllers[name] = true
   }
+}
+
+function canRegisterController(name, application){
+  return !application.router.modulesByIdentifier.has(name)
 }


### PR DESCRIPTION
Fixes issue https://github.com/hotwired/stimulus-rails/issues/111 where lazy loading will attempt to load the external stimulus controller even if it was registered manually. 

Improves on the fix from https://github.com/hotwired/stimulus-rails/pull/97 where a new lookup table is created to check if a controller is registered or not. Stimulus already maintains this mapping [here](https://github.com/hotwired/stimulus-rails/blob/ef2f33d0af802461d9cc431ac5888b2461f71af2/app/assets/javascripts/stimulus.js#L1870) which we can use to determine if a controller was registered outside of `stimulus-loading`'s scope and avoid re-registering it. 