### PR TITLE
Fixed example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,7 @@ export { application }
 
 5. Add the following line to `app/javascript/application.js` to import all your controllers:
 ```javascript
-import "controllers"
-
-// esbuild uses another syntax
-// import "./controllers"
+import "./controllers"
 ```
 
 6. Finally, add the Stimulus package to yarn:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ export { application }
 
 5. Add the following line to `app/javascript/application.js` to import all your controllers:
 ```javascript
-import "./controllers";
+import "controllers";
+
+// esbuild uses another syntax
+// import "./controllers";
 ```
 
 6. Finally, add the Stimulus package to yarn:

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ export { application }
 
 5. Add the following line to `app/javascript/application.js` to import all your controllers:
 ```javascript
-import "controllers";
+import "controllers"
 
 // esbuild uses another syntax
-// import "./controllers";
+// import "./controllers"
 ```
 
 6. Finally, add the Stimulus package to yarn:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export { application }
 
 5. Add the following line to `app/javascript/application.js` to import all your controllers:
 ```javascript
-import "controllers"
+import "./controllers";
 ```
 
 6. Finally, add the Stimulus package to yarn:


### PR DESCRIPTION
If I use ```import controllers``` as mentioned in the README I get the following error:

```
13:15:21 js.1   |   errors: [
13:15:21 js.1   |     {
13:15:21 js.1   |       detail: undefined,
13:15:21 js.1   |       id: '',
13:15:21 js.1   |       location: {
13:15:21 js.1   |         column: 7,
13:15:21 js.1   |         file: 'application.js',
13:15:21 js.1   |         length: 13,
13:15:21 js.1   |         line: 24,
13:15:21 js.1   |         lineText: 'import "controllers";',
13:15:21 js.1   |         namespace: '',
13:15:21 js.1   |         suggestion: '"./controllers"'
13:15:21 js.1   |       },
13:15:21 js.1   |       notes: [
13:15:21 js.1   |         {
13:15:21 js.1   |           location: null,
13:15:21 js.1   |           text: 'Use the relative path "./controllers" to reference the file "controllers/index.js". Without the leading "./", the path "controllers" is being interpreted as a package path instead.'
13:15:21 js.1   |         }
13:15:21 js.1   |       ],
13:15:21 js.1   |       pluginName: '',
13:15:21 js.1   |       text: 'Could not resolve "controllers"'
13:15:21 js.1   |     }
13:15:21 js.1   |   ],
13:15:21 js.1   |   warnings: []
13:15:21 js.1   | }
13:15:21 js.1   | error Command failed with exit code 1.
13:15:21 js.1   | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
13:15:21 js.1   | exited with code 1
```

I fixed the error by implementing the suggested `"./controllers"`.

I don't know if the same error occurs with importmap, because I don't use it.