### PR TITLE
Append new controller import lines to content already within `index.js`

### DIFF
--- a/lib/generators/stimulus/USAGE
+++ b/lib/generators/stimulus/USAGE
@@ -13,3 +13,10 @@ Examples:
     bin/rails generate stimulus nested/chat
 
     creates: app/javascript/controllers/nested/chat_controller.js
+
+
+    bin/rails generate stimulus chat --append
+
+    creates: app/javascript/controllers/chat_controller.js
+    appends: The controller name to controllers/index.js while
+             maintaining the controller index's original state.

--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -2,11 +2,13 @@ require "rails/generators/named_base"
 
 class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
+  class_option :append, type: :boolean, default: false
 
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)
     template "controller.js", "app/javascript/controllers/#{controller_name}_controller.js"
-    rails_command "stimulus:manifest:update" unless Rails.root.join("config/importmap.rb").exist?
+    task = "stimulus:manifest:#{options[:append] ? "append[#{controller_name}]" : "update"}"
+    rails_command task unless Rails.root.join("config/importmap.rb").exist?
   end
 
   private

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -44,5 +44,16 @@ namespace :stimulus do
         index.puts manifest
       end
     end
+
+    task :append, [:controller_name] do |task, args|
+      manifest =
+        Stimulus::Manifest.generate_from(Rails.root.join("app/javascript/controllers"))
+      controller_class = "#{args[:controller_name]}_controller".camelize
+      controller_lines = manifest.split("\n").flatten.select {|line| line.match?(controller_class)}.join("\n")
+
+      File.open(Rails.root.join("app/javascript/controllers/index.js"), "a") do |index|
+        index.puts controller_lines
+      end
+    end
   end
 end


### PR DESCRIPTION
## Appending to `app/javascript/controllers/index.js`

```
rails generate stimulus foo
```

When creating a new Stimulus controller like this, all of the contents of `app/javascript/controllers/index.js` get overwritten in the following code:

https://github.com/hotwired/stimulus-rails/blob/498902a3687d32bd6589f7d3c7e7d72eabd822c0/lib/tasks/stimulus_tasks.rake#L38-L45

I think it would be helpful to simply append the new controller's import lines to the end of the file if you pass an `--append` flag, so this PR enables you to write the following to keep your `index.js` file intact: 

```
rails generate stimulus foo --append
```

## Selecting from `manifest`
```ruby
manifest =
  Stimulus::Manifest.generate_from(Rails.root.join("app/javascript/controllers"))
```

Since these lines grab <b>all</b> of the controllers in the directory, I simply selected the lines related to the new controller only and appended them to the file.

## Testing
I had trouble getting tests to work with the `run_generator` helper. It didn't run the rake task so I'm not entirely sure how to approach these tests. I'd be glad to give it another shot though if appending new controllers in the index file like this is a viable option.