### PR TITLE
Add skip_manifest option to generator

### DIFF
--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -3,10 +3,12 @@ require "rails/generators/named_base"
 class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
 
+  class_option :skip_manifest, type: :boolean, default: false, desc: "Don't update the stimulus manifest"
+
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)
     template "controller.js", "app/javascript/controllers/#{controller_name}_controller.js"
-    rails_command "stimulus:manifest:update" unless Rails.root.join("config/importmap.rb").exist?
+    rails_command "stimulus:manifest:update" unless Rails.root.join("config/importmap.rb").exist? || options[:skip_manifest]
   end
 
   private


### PR DESCRIPTION
Some projects don't need to generate manifest (for example when using [stimulus-controller-resolver](https://github.com/danieldiekmeier/stimulus-controller-resolver)) when generating a new stimulus controller

Here is an option to skip it