### PR TITLE
Use bun for installation if applicable

### DIFF
--- a/lib/install/stimulus_with_bun.rb
+++ b/lib/install/stimulus_with_bun.rb
@@ -1,0 +1,18 @@
+say "Create controllers directory"
+empty_directory "app/javascript/controllers"
+copy_file "#{__dir__}/app/javascript/controllers/index_for_node.js",
+  "app/javascript/controllers/index.js"
+copy_file "#{__dir__}/app/javascript/controllers/application.js",
+  "app/javascript/controllers/application.js"
+copy_file "#{__dir__}/app/javascript/controllers/hello_controller.js",
+  "app/javascript/controllers/hello_controller.js"
+
+if (Rails.root.join("app/javascript/application.js")).exist?
+  say "Import Stimulus controllers"
+  append_to_file "app/javascript/application.js", %(import "./controllers"\n)
+else
+  say %(Couldn't find "app/javascript/application.js".\nYou must import "./controllers" in your JavaScript entrypoint file), :red
+end
+
+say "Install Stimulus"
+run "bun add @hotwired/stimulus"

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -8,11 +8,7 @@ module Stimulus
     end
 
     def using_bun?
-      Rails.root.join("bun.lockb").exist? || (tool_exists?('bun') && !Rails.root.join("yarn.lock").exist?)
-    end
-
-    def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
+      Rails.root.join("bun.config.js").exist?
     end
   end
 end

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -1,15 +1,20 @@
 require "stimulus/manifest"
 
-def run_stimulus_install_template(path)
-  system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
-end
+module Stimulus
+  module Tasks
+    extend self
+    def run_stimulus_install_template(path)
+      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
+    end
 
-def using_bun?
-  Rails.root.join("bun.lockb").exist? || (tool_exists?('bun') && !Rails.root.join("yarn.lock").exist?)
-end
+    def using_bun?
+      Rails.root.join("bun.lockb").exist? || (tool_exists?('bun') && !Rails.root.join("yarn.lock").exist?)
+    end
 
-def tool_exists?(tool)
-  system "command -v #{tool} > /dev/null"
+    def tool_exists?(tool)
+      system "command -v #{tool} > /dev/null"
+    end
+  end
 end
 
 namespace :stimulus do
@@ -17,7 +22,7 @@ namespace :stimulus do
   task :install do
     if Rails.root.join("config/importmap.rb").exist?
       Rake::Task["stimulus:install:importmap"].invoke
-    elsif Rails.root.join("package.json").exist? && using_bun?
+    elsif Rails.root.join("package.json").exist? && Stimulus::Tasks.using_bun?
       Rake::Task["stimulus:install:bun"].invoke
     elsif Rails.root.join("package.json").exist?
       Rake::Task["stimulus:install:node"].invoke
@@ -29,17 +34,17 @@ namespace :stimulus do
   namespace :install do
     desc "Install Stimulus on an app running importmap-rails"
     task :importmap do
-      run_stimulus_install_template "stimulus_with_importmap"
+      Stimulus::Tasks.run_stimulus_install_template "stimulus_with_importmap"
     end
 
     desc "Install Stimulus on an app running node"
     task :node do
-      run_stimulus_install_template "stimulus_with_node"
+      Stimulus::Tasks.run_stimulus_install_template "stimulus_with_node"
     end
 
     desc "Install Stimulus on an app running bun"
     task :bun do
-      run_stimulus_install_template "stimulus_with_bun"
+      Stimulus::Tasks.run_stimulus_install_template "stimulus_with_bun"
     end
   end
 


### PR DESCRIPTION
This PR [is part of an overall effort ](https://github.com/rails/rails/pull/49241) to allow Rails developers to completely use the Bun JS runtime and bundler without needing to use Node.JS and Yarn.

This gem is automatically invoked when a new rails projects is created and before this PR would always use Yarn. After this PR this gem will detect which JS bundler is being used and use the correct one so that Yarn doesn't accidentally slip into your Rails project.

[I have opened a companion PR to the turbo-rails repo as well.](https://github.com/hotwired/turbo-rails/pull/494)

### Example run of `javascript:install:bun` and `bin/rails stimulus:install`

```
☁  test_app [main] ./bin/rails javascript:install:bun
Compile into app/assets/builds
      create  app/assets/builds
      create  app/assets/builds/.keep
      append  app/assets/config/manifest.js
      append  .gitignore
      append  .gitignore
Add JavaScript include tag in application layout
      insert  app/views/layouts/application.html.erb
Create default entrypoint in app/javascript/application.js
      create  app/javascript
      create  app/javascript/application.js
Add default package.json
      create  package.json
Add bin/dev to start foreman
      create  bin/dev
Add default Procfile.dev
      create  Procfile.dev
Ensure foreman is installed
         run  gem install foreman from "."
Successfully installed foreman-0.87.2
Parsing documentation for foreman-0.87.2
Done installing documentation for foreman after 0 seconds
1 gem installed
Add default bun.config.js
      create  bun.config.js
Add build script to package.json
☁  test_app [main] ⚡  bin/rails stimulus:install
Create controllers directory
      create  app/javascript/controllers
      create  app/javascript/controllers/index.js
      create  app/javascript/controllers/application.js
      create  app/javascript/controllers/hello_controller.js
Import Stimulus controllers
      append  app/javascript/application.js
Install Stimulus
         run  bun add @hotwired/stimulus from "."
bun add v1.0.0 (822a00c4)

 installed @hotwired/stimulus@3.2.2


 1 packages installed [931.00ms]
```