### PR TITLE
Support for dasherized controller filenames

### DIFF
--- a/lib/stimulus/manifest.rb
+++ b/lib/stimulus/manifest.rb
@@ -10,7 +10,7 @@ module Stimulus::Manifest
   def import_and_register_controller(controllers_path, controller_path)
     controller_path = controller_path.relative_path_from(controllers_path).to_s
     module_path = controller_path.split('.').first
-    controller_class_name = module_path.camelize.gsub(/::/, "__")
+    controller_class_name = module_path.underscore.camelize.gsub(/::/, "__")
     tag_name = module_path.remove(/_controller/).gsub(/_/, "-").gsub(/\//, "--")
 
     <<-JS

--- a/test/fixtures/controllers/multi-word-dash_controller.js
+++ b/test/fixtures/controllers/multi-word-dash_controller.js
@@ -1,0 +1,4 @@
+// mutli-word-dash_controller.js
+import { Controller } from "stimulus";
+
+export default class extends Controller {}

--- a/test/fixtures/controllers/multi_word_underscore_controller.js
+++ b/test/fixtures/controllers/multi_word_underscore_controller.js
@@ -1,0 +1,4 @@
+// mutli_word_underscore_controller.js
+import { Controller } from "stimulus";
+
+export default class extends Controller {}

--- a/test/fixtures/controllers/namespace/multi-word-dash_controller.js
+++ b/test/fixtures/controllers/namespace/multi-word-dash_controller.js
@@ -1,0 +1,4 @@
+// namespace/multi_word_dash_controller.js
+import { Controller } from "stimulus";
+
+export default class extends Controller {}

--- a/test/fixtures/controllers/namespace/multi_word_underscore_controller.js
+++ b/test/fixtures/controllers/namespace/multi_word_underscore_controller.js
@@ -1,0 +1,4 @@
+// namespace/multi_word_underscore_controller.js
+import { Controller } from "stimulus";
+
+export default class extends Controller {}

--- a/test/fixtures/controllers/namespace/namespaced_controller.js
+++ b/test/fixtures/controllers/namespace/namespaced_controller.js
@@ -1,0 +1,4 @@
+// namespace/namespaced_controller.js
+import { Controller } from "stimulus";
+
+export default class extends Controller {}

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -16,5 +16,25 @@ class Stimulus::Manifest::Test < ActiveSupport::TestCase
     # TypeScript controller
     assert_includes manifest, 'import TypeScriptController from "./type_script_controller"'
     assert_includes manifest, 'application.register("type-script", TypeScriptController)'
+
+    # Multi words controller using dasherized file name
+    assert_includes manifest, 'import MultiWordDashController from "./multi-word-dash_controller"'
+    assert_includes manifest, 'application.register("multi-word-dash", MultiWordDashController)'
+
+    # Multi words controller using underscored file name
+    assert_includes manifest, 'import MultiWordUnderscoreController from "./multi_word_underscore_controller"'
+    assert_includes manifest, 'application.register("multi-word-underscore", MultiWordUnderscoreController)'
+
+    # namespaced controller
+    assert_includes manifest, 'import Namespace__NamespacedController from "./namespace/namespaced_controller"'
+    assert_includes manifest, 'application.register("namespace--namespaced", Namespace__NamespacedController)'
+
+    # namespaced controller with multiple words using dasherized file name
+    assert_includes manifest, 'import Namespace__MultiWordDashController from "./namespace/multi-word-dash_controller"'
+    assert_includes manifest, 'application.register("namespace--multi-word-dash", Namespace__MultiWordDashController)'
+
+    # namespaced controller with multiple words using underscored file name
+    assert_includes manifest, 'import Namespace__MultiWordUnderscoreController from "./namespace/multi_word_underscore_controller"'
+    assert_includes manifest, 'application.register("namespace--multi-word-underscore", Namespace__MultiWordUnderscoreController)'
   end
 end


### PR DESCRIPTION
### Summary

This PR extends the current functionality of the Gem to support Stimulus controllers with dasherized names (`multi-word-dash_controller.js`), in addition to the existing camel_case support (`multi_word_controller.js`).

### Background

The Gem currently supports only Stimulus controllers with names in camel_case.
Dasherized names is part of the Stimulus documentation https://stimulus.hotwired.dev/reference/controllers#identifiers

Given that the controller name written in the DOM is using dash to me it feels more natural to write it like that in my filename.

### Changes

This PR adds support for dasherized controller names and includes a corresponding test case. With these changes, the Gem will support the following naming structures:

```
├── coffee_controller.coffee
├── hello_controller.js
├── multi-word-dash_controller.js
├── multi_word_underscore_controller.js
├── namespace
│   ├── multi-word-dash_controller.js
│   ├── multi_word_underscore_controller.js
│   └── namespaced_controller.js
└── type_script_controller.ts
```
