### PR TITLE
Bun support

### DIFF
--- a/lib/install/stimulus_with_node.rb
+++ b/lib/install/stimulus_with_node.rb
@@ -15,4 +15,8 @@ else
 end
 
 say "Install Stimulus"
-run "yarn add @hotwired/stimulus"
+if Rails.root.join("bun.config.js")).exist?
+  run "bun add @hotwired/stimulus"
+else
+  run "yarn add @hotwired/stimulus"
+end


### PR DESCRIPTION
Add support for bun

If you create a new rails project with "--main --javascript bun"
you end up with a yarn.lock and not a bun.lockb file.  This is
because turbo-rails and stimuls are installed with yarn.