### PR TITLE
Update stimulus_tasks.rake (closes #128)

### DIFF
--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -27,10 +27,12 @@ namespace :stimulus do
   end
 
   namespace :manifest do
+    desc "Show the current Stimulus manifest (all installed controllers)"
     task :display do
       puts Stimulus::Manifest.generate_from(Rails.root.join("app/javascript/controllers"))
     end
 
+    desc "Update the Stimulus manifest (will overwrite controllers/index.js)"
     task :update do
       manifest =
         Stimulus::Manifest.generate_from(Rails.root.join("app/javascript/controllers"))


### PR DESCRIPTION
Describe the two options under stimulus:manifest so they can be found in a `rails -T` listing.