### PR TITLE
fix duplicate controllers in manifest on update

### DIFF
--- a/lib/stimulus/manifest.rb
+++ b/lib/stimulus/manifest.rb
@@ -2,9 +2,11 @@ module Stimulus::Manifest
   extend self
 
   def generate_from(controllers_path)
-    extract_controllers_from(controllers_path).collect do |controller_path|
+    manifest = extract_controllers_from(controllers_path).collect do |controller_path|
       import_and_register_controller(controllers_path, controller_path)
     end
+
+    manifest.uniq
   end
 
   def import_and_register_controller(controllers_path, controller_path)

--- a/test/fixtures/controllers/hello_controller.ts
+++ b/test/fixtures/controllers/hello_controller.ts
@@ -1,0 +1,15 @@
+// hello_controller.ts
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["name", "output"];
+
+  declare readonly nameTarget: HTMLInputElement;
+  declare readonly outputTarget: HTMLElement;
+
+  greet() {
+    this.outputTarget.textContent =
+      `Hello, ${this.nameTarget.value}!`
+  }
+
+}

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -9,6 +9,9 @@ class Stimulus::Manifest::Test < ActiveSupport::TestCase
     assert_includes manifest, 'import HelloController from "./hello_controller"'
     assert_includes manifest, 'application.register("hello", HelloController)'
 
+    assert_equal 1, manifest.scan('import HelloController from "./hello_controller"').length
+    assert_equal 1, manifest.scan('application.register("hello", HelloController').length
+
     # CoffeeScript controller
     assert_includes manifest, 'import CoffeeController from "./coffee_controller"'
     assert_includes manifest, 'application.register("coffee", CoffeeController)'


### PR DESCRIPTION
Fixes https://github.com/hotwired/stimulus/issues/739

when typescript and js controllers are named the same. For example, `hello_controller.js` and `hello_controller.ts` and placed in the controllers folder, `index.js` is updated with duplicate content to register the controllers.

```js
// This file is auto-generated by ./bin/rails stimulus:manifest:update
// Run that command whenever you add a new controller or create them with
// ./bin/rails generate stimulus controllerName

import { application } from "./application"

import HelloController from "./hello_controller"
application.register("hello", HelloController)

import HelloController from "./hello_controller"
application.register("hello", HelloController)
```