### PR TITLE
Fix syntax error in stimulus_with_node.rb

### DIFF
--- a/lib/install/stimulus_with_node.rb
+++ b/lib/install/stimulus_with_node.rb
@@ -15,7 +15,7 @@ else
 end
 
 say "Install Stimulus"
-if Rails.root.join("bun.config.js")).exist?
+if (Rails.root.join("bun.config.js")).exist?
   run "bun add @hotwired/stimulus"
 else
   run "yarn add @hotwired/stimulus"


### PR DESCRIPTION
Fix syntax error:

```
$ rails stimulus:install

gems/stimulus-rails-1.3.2/lib/install/stimulus_with_node.rb:18: syntax error, unexpected ')', expecting `then' or ';' or '\n' (SyntaxError)
...ils.root.join("bun.config.js")).exist?
```

Which introduced in #127