### PR TITLE
Changed install template system call to account for spaces in path

### DIFF
--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -4,7 +4,7 @@ module Stimulus
   module Tasks
     extend self
     def run_stimulus_install_template(path)
-      system {RbConfig.ruby}, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
+      system RbConfig.ruby, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
     end
 
     def using_bun?

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -4,7 +4,7 @@ module Stimulus
   module Tasks
     extend self
     def run_stimulus_install_template(path)
-      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
+      system {RbConfig.ruby}, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
     end
 
     def using_bun?


### PR DESCRIPTION
This is a very small fix to the installation process. In run_stimulus_install_template the path may contain a space. In my case, the bundle directory has a space in it for some reason unknown to me (vendor/bundle /). In the old code this broke the system call and prevented generation of a new rails project by rails new app_name. The new version is in line with other library install templates like importmap)

I'm using rbenv on Arch, ruby 3.3.1, rails 7.1.3.2.
