### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/stimulus-rails

### DIFF
--- a/stimulus-rails.gemspec
+++ b/stimulus-rails.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "A modest JavaScript framework for the HTML you already have."
   spec.license     = "MIT"
 
+  spec.metadata["changelog_uri"] = "https://github.com/hotwired/stimulus-rails/releases"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/hotwired/stimulus-rails"
 


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/stimulus-rails which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/