### PR TITLE
Rethrow error when failing to register a controller

### DIFF
--- a/app/assets/javascripts/stimulus-loading.js
+++ b/app/assets/javascripts/stimulus-loading.js
@@ -25,10 +25,11 @@ function registerControllerFromPath(path, under, application) {
       .then((module) => registerController(name, module, application))
       .catch((error) => {
         if (error instanceof TypeError) {
-          error.message = `Failed to register controller: ${name} (${path})`;
+          error.message = `Failed to register controller: ${name} (${path})`
         }
-        throw error;
-      });
+
+        throw error
+      })
   }
 }
 

--- a/app/assets/javascripts/stimulus-loading.js
+++ b/app/assets/javascripts/stimulus-loading.js
@@ -22,8 +22,8 @@ function registerControllerFromPath(path, under, application) {
 
   if (canRegisterController(name, application)) {
     import(path)
-      .then((module) => registerController(name, module, application))
-      .catch((error) => {
+      .then(module => registerController(name, module, application))
+      .catch(error => {
         if (error instanceof TypeError) {
           error.message = `Failed to register controller: ${name} (${path})`
         }

--- a/app/assets/javascripts/stimulus-loading.js
+++ b/app/assets/javascripts/stimulus-loading.js
@@ -22,8 +22,13 @@ function registerControllerFromPath(path, under, application) {
 
   if (canRegisterController(name, application)) {
     import(path)
-      .then(module => registerController(name, module, application))
-      .catch(error => console.error(`Failed to register controller: ${name} (${path})`, error))
+      .then((module) => registerController(name, module, application))
+      .catch((error) => {
+        if (error instanceof TypeError) {
+          error.message = `Failed to register controller: ${name} (${path})`;
+        }
+        throw error;
+      });
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/hotwired/stimulus-rails/issues/102

When failing to register a controller, Stimulus catches the error and logs a console message. But that means the error won't be logged in a monitoring tool, making it hard to identify the issue.

This change follows the pattern in other files to catch this Type Error, format an error message, and re-throw the error so it can be tracked by monitoring tools.

This is my first contribution to Stimulus, so please let me know what I am missing. Thanks for reviewing it!

#### Before

![Screenshot 2024-09-18 at 10 29 15 AM](https://github.com/user-attachments/assets/1b35b8c8-f7b9-4c99-a49f-51f868e4c217)

#### After

![Screenshot 2024-09-18 at 10 43 39 AM](https://github.com/user-attachments/assets/8364f4c9-d046-4f00-8f6c-a5a13d48e5a4)

PS. I noticed we don't have unit JS tests. Would setting something up for unit tests be a helpful future contribution?