### PR TITLE
Use `tr` instead of `gsub`

### DIFF
--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -17,6 +17,6 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
     end
 
     def stimulus_attribute_value(controller_name)
-      controller_name.gsub(/\//, "--").gsub("_", "-")
+      controller_name.gsub(/\//, "--").tr("_", "-")
     end
 end

--- a/lib/stimulus/manifest.rb
+++ b/lib/stimulus/manifest.rb
@@ -13,7 +13,7 @@ module Stimulus::Manifest
     controller_path = controller_path.relative_path_from(controllers_path).to_s
     module_path = controller_path.split('.').first
     controller_class_name = module_path.underscore.camelize.gsub(/::/, "__")
-    tag_name = module_path.remove(/_controller/).gsub(/_/, "-").gsub(/\//, "--")
+    tag_name = module_path.remove(/_controller/).tr("_", "-").gsub(/\//, "--")
 
     <<-JS
 


### PR DESCRIPTION
`tr` is cheaper to run than `gsub`

Here is a little benchmark example :

```ruby
require 'benchmark'

test_string = "namespace/example_services"

Benchmark.bm(10) do |x|
  x.report("gsub:") do
    1_000_000.times do
      test_string.gsub(/\//, "--").gsub("_", "-")
    end
  end

  x.report("tr:") do
    1_000_000.times do
      test_string.gsub(/\//, "--").tr("_", "-")
    end
  end
end
```

```
                 user     system      total        real
gsub:        1.128953   0.006334   1.135287 (  1.135361)
tr:          0.867549   0.004827   0.872376 (  0.872377)
```