### PR TITLE
Optionally inherit from ApplicationController

### DIFF
--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -19,4 +19,20 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
     def stimulus_attribute_value(controller_name)
       controller_name.gsub(/\//, "--").gsub("_", "-")
     end
+
+    def controller_import
+      if application_controller_exists?
+        'import ApplicationController from "./application_controller"'
+      else
+        'import { Controller } from "@hotwired/stimulus"'
+      end
+    end
+
+    def parent_controller
+      application_controller_exists? ? "ApplicationController" : "Controller"
+    end
+
+    def application_controller_exists?
+      File.exist?(Rails.root.join("app/javascript/controllers/application_controller.js"))
+    end
 end

--- a/lib/generators/stimulus/templates/controller.js.tt
+++ b/lib/generators/stimulus/templates/controller.js.tt
@@ -1,7 +1,7 @@
-import { Controller } from "@hotwired/stimulus"
+<%= controller_import %>
 
-// Connects to data-controller="<%= @attribute %>"
-export default class extends Controller {
+// Connects to data-controller="<%= attribute %>"
+export default class extends <%= parent_controller %> {
   connect() {
   }
 }


### PR DESCRIPTION
This is taken from a custom override I add to all my app's lib folders. 

I prefer to inherit from `ApplicationController` (app/javascript/controller/application_controller.js or whatever is more common/best practice) instead of `Controller`. Similarly how you inherit from `ApplicationController` in a Rails app, and not `ActionController::Base`. 

If `ApplicationController` is not present, fallback to current default.

Possibly quite specific/niche, but wanted to share regardless to see what others think.