### PR TITLE
Support controllers_path generator option for controller and manifest tasks.

### DIFF
--- a/lib/generators/stimulus/USAGE
+++ b/lib/generators/stimulus/USAGE
@@ -13,3 +13,8 @@ Examples:
     bin/rails generate stimulus nested/chat
 
     creates: app/javascript/controllers/nested/chat_controller.js
+
+
+    bin/rails generate stimulus chat --controllers-path=app/frontend/controllers
+
+    creates: app/frontend/controllers/chat_controller.js

--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -7,11 +7,11 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
 
   class_option :skip_manifest, type: :boolean, default: false, desc: "Don't update the stimulus manifest"
-  class_option :js_root, type: :string, default: "app/javascript", desc: "Root path for javascript files"
+  class_option :controllers_path, type: :string, default: "app/javascript/controllers", desc: "Root path for controller files"
 
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)
-    template "controller.js", "#{options.js_root}/controllers/#{controller_name}_controller.js"
+    template "controller.js", "#{options.controllers_path}/#{controller_name}_controller.js"
     rails_command "stimulus:manifest:update" unless update_manifest_index?
   end
 

--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -10,12 +10,23 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   class_option :controllers_path, type: :string, default: "app/javascript/controllers", desc: "Root path for controller files"
 
   def copy_view_files
+    validate_controllers_path
+
     @attribute = stimulus_attribute_value(controller_name)
     template "controller.js", "#{options.controllers_path}/#{controller_name}_controller.js"
     rails_command "stimulus:manifest:update" unless update_manifest_index?
   end
 
   private
+
+    def validate_controllers_path
+      if options.controllers_path.blank?
+        raise "controllers-path cannot be empty"
+      elsif options.controllers_path.start_with?("/")
+        raise "controllers-path cannot be an absolute path: #{options.controllers_path}"
+      end
+    end
+
     def controller_name
       name.underscore.gsub(/_controller$/, "")
     end

--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -5,11 +5,12 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
 
   class_option :skip_manifest, type: :boolean, default: false, desc: "Don't update the stimulus manifest"
+  class_option :js_root, type: :string, default: 'app/javascript', desc: "Root path for javascript files"
 
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)
-    template "controller.js", "app/javascript/controllers/#{controller_name}_controller.js"
-    Stimulus::Manifest.write_index_from(Rails.root.join("app/javascript/controllers")) unless update_manifest_index?
+    template "controller.js", "#{options[:js_root]}/controllers/#{controller_name}_controller.js"
+    rails_command "stimulus:manifest:update" unless update_manifest_index?
   end
 
   private

--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -3,7 +3,6 @@ require "rails/generators/actions"
 require "rails/generators/named_base"
 require "stimulus/manifest"
 
-
 class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
 
@@ -12,7 +11,7 @@ class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
 
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)
-    template "controller.js", "#{options[:js_root]}/controllers/#{controller_name}_controller.js"
+    template "controller.js", "#{options.js_root}/controllers/#{controller_name}_controller.js"
     rails_command "stimulus:manifest:update" unless update_manifest_index?
   end
 

--- a/lib/generators/stimulus/stimulus_generator.rb
+++ b/lib/generators/stimulus/stimulus_generator.rb
@@ -1,11 +1,14 @@
+require "rails/generators"
+require "rails/generators/actions"
 require "rails/generators/named_base"
 require "stimulus/manifest"
+
 
 class StimulusGenerator < Rails::Generators::NamedBase # :nodoc:
   source_root File.expand_path("templates", __dir__)
 
   class_option :skip_manifest, type: :boolean, default: false, desc: "Don't update the stimulus manifest"
-  class_option :js_root, type: :string, default: 'app/javascript', desc: "Root path for javascript files"
+  class_option :js_root, type: :string, default: "app/javascript", desc: "Root path for javascript files"
 
   def copy_view_files
     @attribute = stimulus_attribute_value(controller_name)

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -7,6 +7,11 @@ module Stimulus
       system RbConfig.ruby, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
     end
 
+    def controllers_path
+      js_root = Rails.application.config.generators.options.dig(:stimulus, :js_root) || "app/javascript"
+      Rails.root.join(js_root, "/controllers")
+    end
+
     def using_bun?
       Rails.root.join("bun.config.js").exist?
     end
@@ -46,13 +51,14 @@ namespace :stimulus do
 
   namespace :manifest do
     desc "Show the current Stimulus manifest (all installed controllers)"
-    task :display do
-      puts Stimulus::Manifest.generate_from(Rails.root.join("app/javascript/controllers"))
+
+    task display: :environment do
+      Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_path)
     end
 
     desc "Update the Stimulus manifest (will overwrite controllers/index.js)"
-    task :update do
-      Stimulus::Manifest.write_index_from(Rails.root.join("app/javascript/controllers"))
+    task update: :environment do
+      Stimulus::Manifest.write_index_from(Stimulus::Tasks.controllers_path)
     end
   end
 end

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -9,11 +9,11 @@ module Stimulus
     end
 
     def controllers_path
-      Rails.root.join(StimulusGenerator.new(["stimulus"], generator_options, {}).options.js_root, "controllers")
-    end
-
-    def generator_options
-      Rails.application.config.generators.options.dig(:stimulus)
+      generator_config = Rails.application.config.generators.options.dig(:stimulus)
+      Rails.root.join(
+        StimulusGenerator.new(["stimulus"], generator_config, {}).options.js_root,
+        "controllers"
+      )
     end
 
     def using_bun?

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -57,7 +57,7 @@ namespace :stimulus do
     desc "Show the current Stimulus manifest (all installed controllers)"
 
     task :display do
-      Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_path)
+      puts Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_path)
     end
 
     desc "Update the Stimulus manifest (will overwrite controllers/index.js)"

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -9,8 +9,8 @@ module Stimulus
     end
 
     def controllers_root
-      config = Rails.application.config.generators.options.dig(:stimulus)
-      Rails.root.join(StimulusGenerator.new(["stimulus"], config, {}).options.controllers_path)
+      Rails.root.join \
+        StimulusGenerator.new(["stimulus"], Rails.application.config.generators.options.dig(:stimulus), {}).options.controllers_path
     end
 
     def using_bun?

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -9,11 +9,8 @@ module Stimulus
     end
 
     def controllers_path
-      generator_config = Rails.application.config.generators.options.dig(:stimulus)
-      Rails.root.join(
-        StimulusGenerator.new(["stimulus"], generator_config, {}).options.js_root,
-        "controllers"
-      )
+      config = Rails.application.config.generators.options.dig(:stimulus)
+      Rails.root.join(StimulusGenerator.new(["stimulus"], config, {}).options.js_root, "controllers")
     end
 
     def using_bun?
@@ -55,7 +52,6 @@ namespace :stimulus do
 
   namespace :manifest do
     desc "Show the current Stimulus manifest (all installed controllers)"
-
     task :display do
       puts Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_path)
     end

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -58,7 +58,7 @@ namespace :stimulus do
 
     desc "Update the Stimulus manifest (will overwrite controllers/index.js)"
     task update: :environment do
-      Stimulus::Manifest.write_index_from(Stimulus::Tasks.controllers_path)
+      Stimulus::Manifest.write_index_from(Stimulus::Tasks.controllers_root)
     end
   end
 end

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -1,4 +1,5 @@
 require "stimulus/manifest"
+require "generators/stimulus/stimulus_generator"
 
 module Stimulus
   module Tasks
@@ -8,8 +9,11 @@ module Stimulus
     end
 
     def controllers_path
-      js_root = Rails.application.config.generators.options.dig(:stimulus, :js_root) || "app/javascript"
-      Rails.root.join(js_root, "/controllers")
+      Rails.root.join(StimulusGenerator.new(["stimulus"], generator_options, {}).options.js_root, "controllers")
+    end
+
+    def generator_options
+      Rails.application.config.generators.options.dig(:stimulus)
     end
 
     def using_bun?
@@ -52,7 +56,7 @@ namespace :stimulus do
   namespace :manifest do
     desc "Show the current Stimulus manifest (all installed controllers)"
 
-    task display: :environment do
+    task :display do
       Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_path)
     end
 

--- a/lib/tasks/stimulus_tasks.rake
+++ b/lib/tasks/stimulus_tasks.rake
@@ -8,9 +8,9 @@ module Stimulus
       system RbConfig.ruby, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
     end
 
-    def controllers_path
+    def controllers_root
       config = Rails.application.config.generators.options.dig(:stimulus)
-      Rails.root.join(StimulusGenerator.new(["stimulus"], config, {}).options.js_root, "controllers")
+      Rails.root.join(StimulusGenerator.new(["stimulus"], config, {}).options.controllers_path)
     end
 
     def using_bun?
@@ -53,7 +53,7 @@ namespace :stimulus do
   namespace :manifest do
     desc "Show the current Stimulus manifest (all installed controllers)"
     task :display do
-      puts Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_path)
+      puts Stimulus::Manifest.generate_from(Stimulus::Tasks.controllers_root)
     end
 
     desc "Update the Stimulus manifest (will overwrite controllers/index.js)"

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -90,7 +90,30 @@ class StimulusGeneratorTest < Rails::Generators::TestCase
   test "removes tailing 'controller' in namespaced string" do
     run_generator ["Hello/WorldController"]
 
+    # Access the generator's class variables
+    # Make assertions against the config
+    # assert_equal expected_value, config[:some_key]
+
     assert_file "app/javascript/controllers/hello/world_controller.js", /data-controller="hello--world"/
   end
 
+  test "writes controller to a custom path if specified" do
+    custom_path = "app/custom/controllers"
+    run_generator ["Hello", "--controllers-path=#{custom_path}"]
+
+    assert_file "#{custom_path}/hello_controller.js", /data-controller="hello/
+  end
+
+  test "fails if controllers path is empty" do
+    assert_raises RuntimeError, "controllers-path cannot be empty" do
+      run_generator ["Hello", "--controllers-path="]
+    end
+  end
+
+  test "fails if controllers path is an absolute path" do
+    absolute_path = "/mypath"
+    assert_raises RuntimeError, "controllers-path cannot be an absolute path: #{absolute_path}" do
+      run_generator ["Hello", "--controllers-path=#{absolute_path}"]
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to support paths other than `app/javascript` for the root path in generator and manifest tasks. [Similar](https://github.com/hotwired/stimulus-rails/pull/119) [attempts](https://github.com/hotwired/stimulus-rails/issues/148) have been made/requested, but this PR uses `config.generators` instead of an initializer to set `controllers_path`.  A small drawback is the manifest tasks load `:environment` to access configuration from `application.rb`, but it plays nicely with generator help message and doesn't pollute the `Stimulus` namespace. Here's the usage:

```ruby
module Rails4Lyfe
  class Application < Rails::Application
    ...

    config.generators do |g|
      ...
      g.stimulus :stimulus, skip_manifest: true, controllers_path: 'app/frontend/controllers'
      ...
    end
  end
end
```

I like using the generator because it keeps the controller consistent with the `// Connects to data-controller=..` comment and naming conventions which get tricky with camelCase, under_score and dash-erized in play. Because the [path is hard coded](https://github.com/hotwired/stimulus-rails/blob/96ae4e835af18d4f7eacc73fc7bfa1267bff0bcb/lib/generators/stimulus/stimulus_generator.rb#L10) in the generator, the only option is to monkey patch it. Monkey patching the generator in my project made it difficult to reference the template from inside the gem requiring me to copy template as well. 

If there's support for this option I'd be happy to proceed with updating docs and tests, although I had a pretty tough time getting the suite to run locally.

Thank you for considering this PR. 